### PR TITLE
refactor!: use llm instead of model

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Want to try a different LL​M?
 
 ```bash
 uvx timecopilot forecast https://otexts.com/fpppy/data/AirPassengers.csv \
-  --model openai:gpt-4o
+  --llm openai:gpt-4o
 ```
 
 Have a specific question?
 
 ```bash
 uvx timecopilot forecast https://otexts.com/fpppy/data/AirPassengers.csv \
-  --model openai:gpt-4o \
+  --llm openai:gpt-4o \
   --query "How many air passengers are expected in total in the next 12 months?"
 ```
 
@@ -102,7 +102,7 @@ df = pd.read_csv("data/air_passengers.csv")
 # Initialize the forecasting agent
 # You can use any LLM by specifying the model parameter
 tc = TimeCopilot(
-    model="openai:gpt-4o",
+    llm="openai:gpt-4o",
     retries=3,
 )
 

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -58,7 +58,7 @@ query = """
   use 12 as seasonality
 """ 
 
-tc = TimeCopilot(model="gpt-4o")
+tc = TimeCopilot(llm="gpt-4o")
 
 # Passing `None` simply uses the defaults; they are shown
 # here for clarity but can be omitted.

--- a/timecopilot/_cli.py
+++ b/timecopilot/_cli.py
@@ -19,7 +19,7 @@ class TimeCopilot:
     def forecast(
         self,
         path: str | Path,
-        model: str = "openai:gpt-4o-mini",
+        llm: str = "openai:gpt-4o-mini",
         freq: str | None = None,
         h: int | None = None,
         seasonality: int | None = None,
@@ -29,7 +29,7 @@ class TimeCopilot:
         with self.console.status(
             "[bold blue]TimeCopilot is navigating through time...[/bold blue]"
         ):
-            forecasting_agent = TimeCopilotAgent(model=model, retries=retries)
+            forecasting_agent = TimeCopilotAgent(llm=llm, retries=retries)
             result = forecasting_agent.forecast(
                 df=path,
                 freq=freq,

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel, Field
@@ -268,8 +269,15 @@ class ForecastAgentOutput(BaseModel):
 class TimeCopilot:
     def __init__(
         self,
-        **kwargs,
+        llm: str,
+        **kwargs: Any,
     ):
+        """
+        Args:
+            llm: The LLM to use.
+            **kwargs: Additional keyword arguments to pass to the agent.
+        """
+
         self.system_prompt = f"""
         You're a forecasting expert. You will be given a time series 
         as a list of numbers
@@ -334,10 +342,18 @@ class TimeCopilot:
         - Practical implications of the forecast
         - Thorough responses to user concerns
         """
+
+        if "model" in kwargs:
+            raise ValueError(
+                "model is not allowed to be passed as a keyword argument"
+                "use `llm` instead"
+            )
+
         self.forecasting_agent = Agent(
             deps_type=ExperimentDataset,
             output_type=ForecastAgentOutput,
             system_prompt=self.system_prompt,
+            model=llm,
             **kwargs,
         )
 


### PR DESCRIPTION
this pr deprecates the usage of `model` as parameter to define the `llm` we want to use. the latter is used instead.