### PR TITLE
fix: use None uif user doesn't provide query

### DIFF
--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -499,7 +499,7 @@ class TimeCopilot:
                 `result.output.prettify()` to print a nicely formatted
                 report.
         """
-        query = f"User query: {query}" if query else "User did not provide a query"
+        query = f"User query: {query}" if query else None
         experiment_dataset_parser = ExperimentDatasetParser(
             model=self.forecasting_agent.model,
         )


### PR DESCRIPTION
this pr fixes calling the parser agent if the user does not provide a query. before it was always called suing `TimeCopilot(...).forecast(df=df, query=None)` since in that case `query` was replaced for a text note.