### PR TITLE
tests: add test to ensure every pr can build the docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,16 @@ jobs:
 
       - name: Test import class
         run: uv run -- python -c "from timecopilot import TimeCopilot" 
+
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build docs
+        run: uv run --group docs mkdocs build


### PR DESCRIPTION
this pr fixes \#34. the easiest and \(i think)\ cleanest way to do it is by adding an extra job in the current ci workflow since it runs in every pr, merge to main and on-demand.