### PR TITLE
tests: add tests for basic functionality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,26 @@ jobs:
       - name: Test import class
         run: uv run -- python -c "from timecopilot import TimeCopilot" 
 
+  test-live:
+    name: test live
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6 
+        with:
+          enable-cache: true
+
+      - name: Run tests 
+        run: uv run pytest -m live
+        env: 
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
+
   build-docs:
     name: Build Docs
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ disable_error_code = ["no-redef"]  # for fasthtml
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-m 'not live'"
+markers = [
+    "live: marks tests that require calls to llm providers"
+]
 
 [tool.ruff]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ disable_error_code = ["no-redef"]  # for fasthtml
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not live'"
 
 [tool.ruff]
 fix = true

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,31 @@
+"""
+Test that the agent works with a live LLM.
+Keeping it separate from the other tests because costs and requires a live LLM.
+"""
+
+import pytest
+from utilsforecast.data import generate_series
+
+from timecopilot import TimeCopilot
+
+
+@pytest.mark.live
+def test_forecast_returns_expected_output():
+    df = generate_series(
+        n_series=1,
+        freq="D",
+        min_length=30,
+        static_as_categorical=False,
+    )
+    forecasting_agent = TimeCopilot(
+        llm="openai:gpt-4o-mini",
+        retries=3,
+    )
+    result = forecasting_agent.forecast(
+        df=df,
+        query="Please forecast the series with a horizon of 2 and frequency D.",
+    )
+    assert len(result.output.forecast) == 2
+    assert result.output.is_better_than_seasonal_naive
+    assert result.output.forecast_analysis is not None
+    assert result.output.reason_for_selection is not None


### PR DESCRIPTION
this pr closes \#26. it adds tests for basic functionality and also introduces live tests to verify timecopilot works as expected when calling the llm. for cost purposes, these tests were marked by the `live` flag and excluded from the main tests. they should run in a separate job and just one python version, for the moment.