### PR TITLE
feat: add `TimeCopilotForecaster` class

### DIFF
--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -1,0 +1,54 @@
+import pytest
+from utilsforecast.data import generate_series
+
+from timecopilot.forecaster import TimeCopilotForecaster
+from timecopilot.models import SeasonalNaive, ZeroModel
+
+
+@pytest.fixture
+def models():
+    return [SeasonalNaive(), ZeroModel()]
+
+
+@pytest.mark.parametrize(
+    "freq,h",
+    [
+        ("D", 2),
+        ("W-MON", 3),
+    ],
+)
+def test_forecaster_forecast(models, freq, h):
+    n_uids = 3
+    df = generate_series(n_series=n_uids, freq=freq, min_length=30)
+    forecaster = TimeCopilotForecaster(models=models)
+    fcst_df = forecaster.forecast(df=df, h=h, freq=freq)
+    assert len(fcst_df) == h * n_uids
+    for model in models:
+        assert model.alias in fcst_df.columns
+
+
+@pytest.mark.parametrize(
+    "freq,h,n_windows,step_size",
+    [
+        ("D", 2, 2, 1),
+        ("W-MON", 3, 2, 2),
+    ],
+)
+def test_forecaster_cross_validation(models, freq, h, n_windows, step_size):
+    n_uids = 3
+    df = generate_series(n_series=n_uids, freq=freq, min_length=30)
+    forecaster = TimeCopilotForecaster(models=models)
+    fcst_df = forecaster.cross_validation(
+        df=df,
+        h=h,
+        freq=freq,
+        n_windows=n_windows,
+        step_size=step_size,
+    )
+    uids = df["unique_id"].unique()
+    for uid in uids:  # noqa: B007
+        fcst_df_uid = fcst_df.query("unique_id == @uid")
+        assert fcst_df_uid["cutoff"].nunique() == n_windows
+        assert len(fcst_df_uid) == n_windows * h
+    for model in models:
+        assert model.alias in fcst_df.columns

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+from .models.utils.forecaster import Forecaster
+
+
+class TimeCopilotForecaster:
+    def __init__(self, models: list[Forecaster]):
+        self.models = models
+
+    def _call_models(
+        self,
+        attr: str,
+        merge_on: list[str],
+        df: pd.DataFrame,
+        h: int,
+        freq: str,
+        **kwargs,
+    ) -> pd.DataFrame:
+        res_df: pd.DataFrame | None = None
+        for model in self.models:
+            res_df_model = getattr(model, attr)(df=df, h=h, freq=freq, **kwargs)
+            if res_df is None:
+                res_df = res_df_model
+            else:
+                res_df = res_df.merge(
+                    res_df_model,
+                    on=merge_on,
+                )
+        return res_df
+
+    def forecast(
+        self,
+        df: pd.DataFrame,
+        h: int,
+        freq: str,
+    ) -> pd.DataFrame:
+        return self._call_models(
+            "forecast",
+            merge_on=["unique_id", "ds"],
+            df=df,
+            h=h,
+            freq=freq,
+        )
+
+    def cross_validation(
+        self,
+        df: pd.DataFrame,
+        h: int,
+        freq: str,
+        n_windows: int = 1,
+        step_size: int | None = None,
+    ) -> pd.DataFrame:
+        return self._call_models(
+            "cross_validation",
+            merge_on=["unique_id", "ds", "cutoff"],
+            df=df,
+            h=h,
+            freq=freq,
+            n_windows=n_windows,
+            step_size=step_size,
+        )

--- a/timecopilot/models/__init__.py
+++ b/timecopilot/models/__init__.py
@@ -1,0 +1,27 @@
+from .benchmarks import (
+    ADIDA,
+    IMAPA,
+    AutoARIMA,
+    AutoCES,
+    AutoETS,
+    CrostonClassic,
+    DOTheta,
+    HistoricAverage,
+    SeasonalNaive,
+    Theta,
+    ZeroModel,
+)
+
+__all__ = [
+    "ADIDA",
+    "IMAPA",
+    "AutoARIMA",
+    "AutoCES",
+    "AutoETS",
+    "CrostonClassic",
+    "DOTheta",
+    "HistoricAverage",
+    "SeasonalNaive",
+    "Theta",
+    "ZeroModel",
+]


### PR DESCRIPTION
this pr closes \#47. the class allows users to forecast and cross validate different `Forecaster` models