### PR TITLE
feat: use timecopilot forecaster class in agent

### DIFF
--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -46,7 +46,7 @@ def test_forecaster_cross_validation(models, freq, h, n_windows, step_size):
         n_windows=n_windows,
         step_size=step_size,
     )
-    assert len(fcst_df.columns) == 3 + len(models)
+    assert len(fcst_df.columns) == 4 + len(models)
     uids = df["unique_id"].unique()
     for uid in uids:  # noqa: B007
         fcst_df_uid = fcst_df.query("unique_id == @uid")

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -67,3 +67,17 @@ def test_forecaster_forecast_with_level(models):
         for lv in level:
             assert f"{model.alias}-lo-{lv}" in fcst_df.columns
             assert f"{model.alias}-hi-{lv}" in fcst_df.columns
+
+
+def test_forecaster_forecast_with_quantiles(models):
+    n_uids = 3
+    quantiles = [0.1, 0.9]
+    df = generate_series(n_series=n_uids, freq="D", min_length=30)
+    forecaster = TimeCopilotForecaster(models=models)
+    fcst_df = forecaster.forecast(df=df, h=2, freq="D", quantiles=quantiles)
+    assert len(fcst_df) == 2 * n_uids
+    assert len(fcst_df.columns) == 2 + len(models) * (1 + len(quantiles))
+    for model in models:
+        assert model.alias in fcst_df.columns
+        for q in quantiles:
+            assert f"{model.alias}-q-{int(100 * q)}" in fcst_df.columns

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -22,6 +22,7 @@ def test_forecaster_forecast(models, freq, h):
     df = generate_series(n_series=n_uids, freq=freq, min_length=30)
     forecaster = TimeCopilotForecaster(models=models)
     fcst_df = forecaster.forecast(df=df, h=h, freq=freq)
+    assert len(fcst_df.columns) == 2 + len(models)
     assert len(fcst_df) == h * n_uids
     for model in models:
         assert model.alias in fcst_df.columns
@@ -45,6 +46,7 @@ def test_forecaster_cross_validation(models, freq, h, n_windows, step_size):
         n_windows=n_windows,
         step_size=step_size,
     )
+    assert len(fcst_df.columns) == 3 + len(models)
     uids = df["unique_id"].unique()
     for uid in uids:  # noqa: B007
         fcst_df_uid = fcst_df.query("unique_id == @uid")

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -52,3 +52,18 @@ def test_forecaster_cross_validation(models, freq, h, n_windows, step_size):
         assert len(fcst_df_uid) == n_windows * h
     for model in models:
         assert model.alias in fcst_df.columns
+
+
+def test_forecaster_forecast_with_level(models):
+    n_uids = 3
+    level = [80, 90]
+    df = generate_series(n_series=n_uids, freq="D", min_length=30)
+    forecaster = TimeCopilotForecaster(models=models)
+    fcst_df = forecaster.forecast(df=df, h=2, freq="D", level=level)
+    assert len(fcst_df) == 2 * n_uids
+    assert len(fcst_df.columns) == 2 + len(models) * (1 + 2 * len(level))
+    for model in models:
+        assert model.alias in fcst_df.columns
+        for lv in level:
+            assert f"{model.alias}-lo-{lv}" in fcst_df.columns
+            assert f"{model.alias}-hi-{lv}" in fcst_df.columns

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -31,6 +31,12 @@ class TimeCopilotForecaster:
             if res_df is None:
                 res_df = res_df_model
             else:
+                if "y" in res_df_model:
+                    # drop y to avoid duplicate columns
+                    # y was added by the previous condition
+                    # to cross validation
+                    # (the initial model)
+                    res_df_model = res_df_model.drop(columns=["y"])
                 res_df = res_df.merge(
                     res_df_model,
                     on=merge_on,

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -14,11 +14,20 @@ class TimeCopilotForecaster:
         df: pd.DataFrame,
         h: int,
         freq: str,
+        level: list[int] | None = None,
+        quantiles: list[float] | None = None,
         **kwargs,
     ) -> pd.DataFrame:
         res_df: pd.DataFrame | None = None
         for model in self.models:
-            res_df_model = getattr(model, attr)(df=df, h=h, freq=freq, **kwargs)
+            res_df_model = getattr(model, attr)(
+                df=df,
+                h=h,
+                freq=freq,
+                level=level,
+                quantiles=quantiles,
+                **kwargs,
+            )
             if res_df is None:
                 res_df = res_df_model
             else:
@@ -33,6 +42,8 @@ class TimeCopilotForecaster:
         df: pd.DataFrame,
         h: int,
         freq: str,
+        level: list[int] | None = None,
+        quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
         return self._call_models(
             "forecast",
@@ -40,6 +51,8 @@ class TimeCopilotForecaster:
             df=df,
             h=h,
             freq=freq,
+            level=level,
+            quantiles=quantiles,
         )
 
     def cross_validation(
@@ -49,6 +62,8 @@ class TimeCopilotForecaster:
         freq: str,
         n_windows: int = 1,
         step_size: int | None = None,
+        level: list[int] | None = None,
+        quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
         return self._call_models(
             "cross_validation",
@@ -58,4 +73,6 @@ class TimeCopilotForecaster:
             freq=freq,
             n_windows=n_windows,
             step_size=step_size,
+            level=level,
+            quantiles=quantiles,
         )


### PR DESCRIPTION
this pr modifies the codebase of the agent to use the `TimeCopilotForecaster` instead of looping trough the list of models.