### PR TITLE
feat(tests): add tests for markdown based documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           enable-cache: true
 
       - name: Run tests 
-        run: uv run pytest -m live
+        run: uv run pytest -m live -n 1
         env: 
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           enable-cache: true
 
       - name: Run tests 
-        run: uv run pytest -m live -n 1
+        run: uv run pytest -m live -n 0
         env: 
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
 

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -12,8 +12,7 @@ You can:
 
 * **`freq`**: the pandas frequency string that describes the spacing of your
   timestamps (`"H"` for hourly, `"D"` for daily, `"MS"` for monthly-start,
-  etc.).  It tells the models how many observations occur in one unit of
-  *seasonality*.
+  etc.).  
 * **`seasonality`**: the length of the dominant seasonal cycle expressed in
   number of `freq` periods (24 for hourly data with a daily cycle, 12 for
   monthly‐start data with a yearly cycle, …).  See
@@ -55,7 +54,7 @@ from timecopilot.agent import TimeCopilot
 df = pd.read_csv("https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv")
 query = """
   Which months will have peak passenger traffic in the next 24 months? 
-  use 12 as seasonality
+  use 12 as seasonality and "MS" as frequency
 """ 
 
 tc = TimeCopilot(llm="gpt-4o")
@@ -64,8 +63,8 @@ tc = TimeCopilot(llm="gpt-4o")
 # here for clarity but can be omitted.
 result = tc.forecast(
     df=df,
-    freq="MS",          
     query=query,
+    freq=None,          # default, infer from query/df
     h=None,             # default, infer from query/df
     seasonality=None,   # default, infer from query/df
 )

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -54,7 +54,7 @@ from timecopilot.agent import TimeCopilot
 df = pd.read_csv("https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv")
 query = """
   Which months will have peak passenger traffic in the next 24 months? 
-  use 12 as seasonality and "MS" as frequency
+  use 12 as seasonality, and "MS" as frequency
 """ 
 
 tc = TimeCopilot(llm="gpt-4o")

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -64,7 +64,7 @@ tc = TimeCopilot(llm="gpt-4o")
 # here for clarity but can be omitted.
 result = tc.forecast(
     df=df,
-    freq="MS",          
+    freq="MS",
     query=query,
     h=None,             # default, infer from query/df
     seasonality=None,   # default, infer from query/df

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -64,8 +64,8 @@ tc = TimeCopilot(llm="gpt-4o")
 # here for clarity but can be omitted.
 result = tc.forecast(
     df=df,
+    freq="MS",          
     query=query,
-    freq=None,          # default, infer from query/df
     h=None,             # default, infer from query/df
     seasonality=None,   # default, infer from query/df
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "mktestdocs>=0.2.4",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -1,0 +1,15 @@
+import pathlib
+
+import pytest
+from mktestdocs import check_md_file
+
+
+@pytest.mark.live
+@pytest.mark.parametrize("fpath", pathlib.Path("docs").glob("**/*.md"), ids=str)
+def test_docs(fpath):
+    check_md_file(fpath=fpath, memory=True)
+
+
+@pytest.mark.live
+def test_readme():
+    check_md_file("README.md", memory=True)

--- a/timecopilot/utils/experiment_handler.py
+++ b/timecopilot/utils/experiment_handler.py
@@ -144,11 +144,10 @@ class ExperimentDatasetParser:
         if query:
             query = f"User query: {query}"
             dataset_params = self.parser_agent.run_sync(user_prompt=query).output
-            # Use provided non-None parameters if any are None
-            # in the inferred dataset_params
-            dataset_params.freq = dataset_params.freq or freq
-            dataset_params.seasonality = dataset_params.seasonality or seasonality
-            dataset_params.h = dataset_params.h or h
+            # user provided parameters take precedence over inferred parameters
+            dataset_params.freq = freq or dataset_params.freq
+            dataset_params.seasonality = seasonality or dataset_params.seasonality
+            dataset_params.h = h or dataset_params.h
         else:
             dataset_params = DatasetParams(
                 freq=freq,

--- a/uv.lock
+++ b/uv.lock
@@ -1947,6 +1947,14 @@ wheels = [
 ]
 
 [[package]]
+name = "mktestdocs"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/fd/f5abdc81159ebc960c4e75aeef0731143a7bb705e44b7b91f86369a254ab/mktestdocs-0.2.4-py2.py3-none-any.whl", hash = "sha256:10b047aec287ac4703e121515a76b133c611122280c69017f54d2e7d080cc880", size = 7141, upload-time = "2024-10-24T12:50:02.787Z" },
+]
+
+[[package]]
 name = "modal"
 version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3998,6 +4006,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mktestdocs" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -4028,6 +4037,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mktestdocs", specifier = ">=0.2.4" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },


### PR DESCRIPTION
this pr adds `mktestdocs` as dev dependency. it allows us to test that `python` cell blocks in our markdown-based documentation are actually correct (ie. they run). the process helped to find an error in our docs that is fixed now by this same pr. happy that now we are testing our `README.md` file.:)