### PR TITLE
docs: document foundation models constructors

### DIFF
--- a/timecopilot/models/foundational/chronos.py
+++ b/timecopilot/models/foundational/chronos.py
@@ -15,6 +15,42 @@ class Chronos(Forecaster):
         batch_size: int = 16,
         alias: str = "Chronos",
     ):
+        """Initialize a Chronos time series forecasting model.
+
+        Loads a pretrained Chronos model from the Hugging Face Hub or a local
+        directory. Chronos models are large language models for time series
+        forecasting, supporting both probabilistic and point forecasts. See
+        the [official repo](https://github.com/amazon-science/
+        chronos-forecasting)
+        for more details.
+
+        Args:
+            repo_id (str, optional): The Hugging Face Hub model ID or local
+                path to load the Chronos model from. Examples include
+                "amazon/chronos-t5-tiny", "amazon/chronos-t5-large", or a
+                local directory. Defaults to "amazon/chronos-t5-large". See
+                the full list of available models at
+                [Hugging Face](https://huggingface.co/collections/
+                amazon/chronos-models-65f1791d630a8d57cb718444)
+            batch_size (int, optional): Batch size to use for inference.
+                Larger models may require smaller batch sizes due to GPU
+                memory constraints. Defaults to 16. For Chronos-Bolt models,
+                higher batch sizes (e.g., 256) are possible.
+            alias (str, optional): Name to use for the model in output
+                DataFrames and logs. Defaults to "Chronos".
+
+        Notes:
+            - The model is loaded onto the best available device (GPU if
+              available, otherwise CPU).
+            - For best performance with large models (e.g., "chronos-t5-large"),
+              a CUDA-compatible GPU is recommended.
+            - The model weights are loaded with torch_dtype=torch.bfloat16 for
+              efficiency on supported hardware.
+            - For more information, see the
+              [Chronos documentation](
+              https://github.com/amazon-science/chronos-forecasting)
+
+        """
         self.repo_id = repo_id
         self.batch_size = batch_size
         self.alias = alias

--- a/timecopilot/models/foundational/timesfm.py
+++ b/timecopilot/models/foundational/timesfm.py
@@ -17,6 +17,45 @@ class TimesFM(Forecaster):
         model_dims: int = 1280,
         alias: str = "TimesFM",
     ):
+        """Initialize a TimesFM time series forecasting model.
+
+        Loads a pretrained TimesFM model from the Hugging Face Hub or a local directory.
+        TimesFM is a large language model for time series forecasting, supporting both
+        probabilistic and point forecasts. See the [official repo](https://github.com/
+        google-research/timesfm) for more details.
+
+        Args:
+            repo_id (str, optional): The Hugging Face Hub model ID or local path to
+                load the TimesFM model from. Examples include
+                "google/timesfm-1.0-200m-pytorch". Defaults to
+                "google/timesfm-1.0-200m-pytorch". See the full list of models at
+                [Hugging Face](https://huggingface.co/collections/google/timesfm-release-
+                66e4be5fdb56e960c1e482a6).
+            context_length (int, optional): Maximum context length (input window size)
+                for the model. Defaults to 512. For TimesFM 2.0 models, max is 2048
+                (must be a multiple of 32). See [TimesFM docs](https://github.com/google-
+                research/timesfm#loading-the-model) for details.
+            per_core_batch_size (int, optional): Batch size per device/core for
+                inference. Defaults to 64. Adjust based on available memory and model
+                size.
+            num_layers (int, optional): Number of transformer layers in the model.
+                Defaults to 20. Should match the configuration of the pretrained
+                checkpoint.
+            model_dims (int, optional): Model hidden dimension size. Defaults to 1280.
+                Should match the configuration of the pretrained checkpoint.
+            alias (str, optional): Name to use for the model in output DataFrames and
+                logs. Defaults to "TimesFM".
+
+        Notes:
+            - Only PyTorch checkpoints are currently supported. JAX is not supported.
+            - TimesFM 2.0 models are not yet supported. See
+              [issue #269](https://github.com/google-research/timesfm/issues/269)
+              for more details.
+            - The model is loaded onto the best available device (GPU if available,
+              otherwise CPU).
+            - For more information, see the
+              [TimesFM documentation](https://github.com/google-research/timesfm).
+        """
         if "pytorch" not in repo_id:
             raise ValueError(
                 "TimesFM only supports pytorch models, "

--- a/timecopilot/models/foundational/tirex.py
+++ b/timecopilot/models/foundational/tirex.py
@@ -21,6 +21,34 @@ class TiRex(Forecaster):
         batch_size: int = 16,
         alias: str = "TiRex",
     ):
+        """Initialize a TiRex time series forecasting model.
+
+        Loads a pretrained TiRex model from the Hugging Face Hub or a local directory.
+        TiRex is a zero-shot time series forecasting model based on xLSTM,
+        supporting both point and quantile predictions for long and short horizons.
+        See the [official repo](https://github.com/NX-AI/tirex) for more details.
+
+        Args:
+            repo_id (str, optional): The Hugging Face Hub model ID or local path to load
+                the TiRex model from. Examples include "NX-AI/TiRex". Defaults to
+                "NX-AI/TiRex". See the full list of models at
+                [Hugging Face](https://huggingface.co/NX-AI).
+            batch_size (int, optional): Batch size to use for inference. Defaults to 16.
+                Adjust based on available memory and model size.
+            alias (str, optional): Name to use for the model in output DataFrames
+                and logs. Defaults to "TiRex".
+
+        Notes:
+            - The model is loaded onto the best available device (GPU if available,
+              otherwise CPU).
+            - On CPU, CUDA kernels are disabled automatically. See the
+              [CUDA kernels section](https://github.com/NX-AI/tirex#cuda-kernels)
+              for details.
+            - For best performance, a CUDA-capable GPU with compute capability >= 8.0
+              is recommended.
+            - For more information, see the
+              [TiRex documentation](https://github.com/NX-AI/tirex).
+        """
         self.repo_id = repo_id
         self.batch_size = batch_size
         self.alias = alias

--- a/timecopilot/models/foundational/toto.py
+++ b/timecopilot/models/foundational/toto.py
@@ -158,6 +158,51 @@ class Toto(Forecaster):
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
+        """Generate forecasts for time series data using the model.
+
+        This method produces point forecasts and, optionally, prediction
+        intervals or quantile forecasts. The input DataFrame can contain one
+        or multiple time series in stacked (long) format.
+
+        Args:
+            df (pd.DataFrame):
+                DataFrame containing the time series to forecast. It must
+                include as columns:
+
+                    - "unique_id": an ID column to distinguish multiple series.
+                    - "ds": a time column indicating timestamps or periods.
+                    - "y": a target column with the observed values.
+
+            h (int):
+                Forecast horizon specifying how many future steps to predict.
+            freq (str):
+                Frequency of the time series (e.g. "D" for daily, "M" for
+                monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
+                pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
+                valid values.
+            level (list[int | float], optional):
+                Confidence levels for prediction intervals, expressed as
+                percentages (e.g. [80, 95]). If provided, the returned
+                DataFrame will include lower and upper interval columns for
+                each specified level.
+            quantiles (list[float], optional):
+                List of quantiles to forecast, expressed as floats between 0
+                and 1. Should not be used simultaneously with `level`. When
+                provided, the output DataFrame will contain additional columns
+                named in the format "model-q-{percentile}", where {percentile}
+                = 100 × quantile value.
+
+        Returns:
+            pd.DataFrame:
+                DataFrame containing forecast results. Includes:
+
+                    - point forecasts for each timestamp and series.
+                    - prediction intervals if `level` is specified.
+                    - quantile forecasts if `quantiles` is specified.
+
+                For multi-series data, the output retains the same unique
+                identifiers as the input DataFrame.
+        """
         qc = QuantileConverter(level=level, quantiles=quantiles)
         dataset = TimeSeriesDataset.from_df(df, batch_size=self.batch_size)
         fcst_df = dataset.make_future_dataframe(h=h, freq=freq)


### PR DESCRIPTION
this pr documents foundational models constructors for those that are being currently supported and tested. closes \#84.