### PR TITLE
feat: make freq parameter optional

### DIFF
--- a/docs/api/models/utils/forecaster.md
+++ b/docs/api/models/utils/forecaster.md
@@ -4,3 +4,4 @@
     options:
         members:
             - get_seasonality
+            - maybe_infer_freq

--- a/docs/forecasting_parameters.md
+++ b/docs/forecasting_parameters.md
@@ -37,7 +37,7 @@ With these concepts in mind, let's see how [`TimeCopilot`][timecopilot.agent.Tim
    `seasonality=` ) fills the gaps left by the query.
 3. **Automatic inference is the fallback.**
    If a value is still unknown it is inferred from the data frame:
-    * `freq`: [`pd.infer_freq(df["ds"])`](https://pandas.pydata.org/docs/reference/api/pandas.infer_freq.html)
+    * `freq`: [`maybe_infer_freq(df)`][timecopilot.models.utils.forecaster.maybe_infer_freq]
     * `seasonality`: [`get_seasonality(freq)`][timecopilot.models.utils.forecaster.get_seasonality]
     * `h`: `2 * seasonality`
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -19,6 +19,23 @@ def test_tirex_import_fails():
 
 @pytest.mark.parametrize("model", models)
 @pytest.mark.parametrize("freq", ["H", "D", "W-MON", "MS"])
+def test_freq_inferred_correctly(model, freq):
+    n_series = 2
+    df = generate_series(
+        n_series,
+        freq=freq,
+    )
+    df["unique_id"] = df["unique_id"].astype(str)
+    fcsts_no_freq = model.forecast(df, h=3)
+    fcsts_with_freq = model.forecast(df, h=3, freq=freq)
+    cv_no_freq = model.cross_validation(df, h=3)
+    cv_with_freq = model.cross_validation(df, h=3, freq=freq)
+    pd.testing.assert_frame_equal(fcsts_no_freq, fcsts_with_freq)
+    pd.testing.assert_frame_equal(cv_no_freq, cv_with_freq)
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("freq", ["H", "D", "W-MON", "MS"])
 @pytest.mark.parametrize("h", [1, 12])
 def test_correct_forecast_dates(model, freq, h):
     n_series = 5

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -30,8 +30,18 @@ def test_freq_inferred_correctly(model, freq):
     fcsts_with_freq = model.forecast(df, h=3, freq=freq)
     cv_no_freq = model.cross_validation(df, h=3)
     cv_with_freq = model.cross_validation(df, h=3, freq=freq)
-    pd.testing.assert_frame_equal(fcsts_no_freq, fcsts_with_freq)
-    pd.testing.assert_frame_equal(cv_no_freq, cv_with_freq)
+    # some foundation models produce different results
+    # each time they are called
+    cols_to_check = ["unique_id", "ds"]
+    cols_to_check_cv = ["unique_id", "ds", "y", "cutoff"]
+    pd.testing.assert_frame_equal(
+        fcsts_no_freq[cols_to_check],
+        fcsts_with_freq[cols_to_check],
+    )
+    pd.testing.assert_frame_equal(
+        cv_no_freq[cols_to_check_cv],
+        cv_with_freq[cols_to_check_cv],
+    )
 
 
 @pytest.mark.parametrize("model", models)

--- a/tests/models/utils/test_forecaster.py
+++ b/tests/models/utils/test_forecaster.py
@@ -8,13 +8,13 @@ from timecopilot.models.utils.forecaster import QuantileConverter, get_seasonali
 
 def test_maybe_get_seasonality_explicit():
     model = SeasonalNaive(season_length=4)
-    assert model.maybe_get_seasonality("D") == 4
+    assert model._maybe_get_seasonality("D") == 4
 
 
 @pytest.mark.parametrize("freq", ["M", "W-MON", "D"])
 def test_maybe_get_seasonality_infer(freq):
     model = SeasonalNaive(season_length=None)
-    assert model.maybe_get_seasonality(freq) == get_seasonality(freq)
+    assert model._maybe_get_seasonality(freq) == get_seasonality(freq)
 
 
 @pytest.mark.parametrize("freq", ["M", "W-MON", "D"])

--- a/tests/models/utils/test_forecaster.py
+++ b/tests/models/utils/test_forecaster.py
@@ -3,7 +3,21 @@ import pytest
 from utilsforecast.data import generate_series
 
 from timecopilot.models.benchmarks.stats import SeasonalNaive
-from timecopilot.models.utils.forecaster import QuantileConverter, get_seasonality
+from timecopilot.models.utils.forecaster import (
+    QuantileConverter,
+    get_seasonality,
+    maybe_infer_freq,
+)
+
+
+@pytest.mark.parametrize("freq", ["ME", "MS", "W-MON", "D"])
+def test_maybe_infer_freq(freq):
+    df = generate_series(
+        n_series=2,
+        freq=freq,
+    )
+    assert maybe_infer_freq(df, None) == freq
+    assert maybe_infer_freq(df, "H") == "H"
 
 
 def test_maybe_get_seasonality_explicit():
@@ -11,13 +25,13 @@ def test_maybe_get_seasonality_explicit():
     assert model._maybe_get_seasonality("D") == 4
 
 
-@pytest.mark.parametrize("freq", ["M", "W-MON", "D"])
+@pytest.mark.parametrize("freq", ["M", "MS", "W-MON", "D"])
 def test_maybe_get_seasonality_infer(freq):
     model = SeasonalNaive(season_length=None)
     assert model._maybe_get_seasonality(freq) == get_seasonality(freq)
 
 
-@pytest.mark.parametrize("freq", ["M", "W-MON", "D"])
+@pytest.mark.parametrize("freq", ["M", "MS", "W-MON", "D"])
 def test_get_seasonality_inferred_correctly(freq):
     season_length = get_seasonality(freq)
     y = 2 * list(range(1, season_length + 1))

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from .models.utils.forecaster import Forecaster
+from .models.utils.forecaster import Forecaster, maybe_infer_freq
 
 
 class TimeCopilotForecaster:
@@ -47,10 +47,12 @@ class TimeCopilotForecaster:
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
+        # infer just once to avoid multiple calls to _maybe_infer_freq
+        freq = maybe_infer_freq(df, freq)
         return self._call_models(
             "forecast",
             merge_on=["unique_id", "ds"],
@@ -65,12 +67,14 @@ class TimeCopilotForecaster:
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         n_windows: int = 1,
         step_size: int | None = None,
         level: list[int] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
+        # infer just once to avoid multiple calls to _maybe_infer_freq
+        freq = maybe_infer_freq(df, freq)
         return self._call_models(
             "cross_validation",
             merge_on=["unique_id", "ds", "cutoff"],

--- a/timecopilot/models/benchmarks/prophet.py
+++ b/timecopilot/models/benchmarks/prophet.py
@@ -5,11 +5,11 @@ import pandas as pd
 from prophet import Prophet as ProphetBase
 from threadpoolctl import threadpool_limits
 
-from ..utils.forecaster import Forecaster, QuantileConverter
+from ..utils.forecaster import QuantileConverter
 from ..utils.parallel_forecaster import ParallelForecaster
 
 
-class Prophet(ProphetBase, ParallelForecaster, Forecaster):
+class Prophet(ProphetBase, ParallelForecaster):
     """
     Wrapper for Facebook Prophet for time series forecasting.
 

--- a/timecopilot/models/benchmarks/stats.py
+++ b/timecopilot/models/benchmarks/stats.py
@@ -94,7 +94,7 @@ class ADIDA(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -115,11 +115,12 @@ class ADIDA(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -143,6 +144,7 @@ class ADIDA(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = run_statsforecast_model(
             model=_ADIDA(alias=self.alias),
             df=df,
@@ -277,7 +279,7 @@ class AutoARIMA(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -298,11 +300,12 @@ class AutoARIMA(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -326,6 +329,7 @@ class AutoARIMA(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoARIMA(
@@ -404,7 +408,7 @@ class AutoCES(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -425,11 +429,12 @@ class AutoCES(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -453,6 +458,7 @@ class AutoCES(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoCES(
@@ -508,7 +514,7 @@ class AutoETS(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -529,11 +535,12 @@ class AutoETS(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -557,6 +564,7 @@ class AutoETS(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoETS(
@@ -598,7 +606,7 @@ class CrostonClassic(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -619,11 +627,12 @@ class CrostonClassic(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -647,6 +656,7 @@ class CrostonClassic(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = run_statsforecast_model(
             model=_CrostonClassic(
                 alias=self.alias,
@@ -684,7 +694,7 @@ class DynamicOptimizedTheta(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -705,11 +715,12 @@ class DynamicOptimizedTheta(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -733,6 +744,7 @@ class DynamicOptimizedTheta(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_DynamicOptimizedTheta(
@@ -771,7 +783,7 @@ class HistoricAverage(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -792,11 +804,12 @@ class HistoricAverage(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -820,6 +833,7 @@ class HistoricAverage(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = run_statsforecast_model(
             model=_HistoricAverage(
                 alias=self.alias,
@@ -857,7 +871,7 @@ class IMAPA(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -878,11 +892,12 @@ class IMAPA(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -906,6 +921,7 @@ class IMAPA(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = run_statsforecast_model(
             model=_IMAPA(
                 alias=self.alias,
@@ -943,7 +959,7 @@ class SeasonalNaive(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -964,11 +980,12 @@ class SeasonalNaive(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -992,6 +1009,7 @@ class SeasonalNaive(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_SeasonalNaive(
@@ -1031,7 +1049,7 @@ class Theta(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -1052,11 +1070,12 @@ class Theta(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -1080,6 +1099,7 @@ class Theta(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_Theta(
@@ -1118,7 +1138,7 @@ class ZeroModel(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -1139,11 +1159,12 @@ class ZeroModel(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -1167,6 +1188,7 @@ class ZeroModel(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = run_statsforecast_model(
             model=_ZeroModel(
                 alias=self.alias,

--- a/timecopilot/models/benchmarks/stats.py
+++ b/timecopilot/models/benchmarks/stats.py
@@ -326,7 +326,7 @@ class AutoARIMA(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoARIMA(
                 d=self.d,
@@ -453,7 +453,7 @@ class AutoCES(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoCES(
                 season_length=season_length,
@@ -557,7 +557,7 @@ class AutoETS(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_AutoETS(
                 season_length=season_length,
@@ -733,7 +733,7 @@ class DynamicOptimizedTheta(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_DynamicOptimizedTheta(
                 season_length=season_length,
@@ -992,7 +992,7 @@ class SeasonalNaive(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_SeasonalNaive(
                 season_length=season_length,
@@ -1080,7 +1080,7 @@ class Theta(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
-        season_length = self.maybe_get_seasonality(freq)
+        season_length = self._maybe_get_seasonality(freq)
         fcst_df = run_statsforecast_model(
             model=_Theta(
                 season_length=season_length,

--- a/timecopilot/models/foundational/chronos.py
+++ b/timecopilot/models/foundational/chronos.py
@@ -164,6 +164,7 @@ class Chronos(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         qc = QuantileConverter(level=level, quantiles=quantiles)
         dataset = TimeSeriesDataset.from_df(df, batch_size=self.batch_size)
         fcst_df = dataset.make_future_dataframe(h=h, freq=freq)

--- a/timecopilot/models/foundational/chronos.py
+++ b/timecopilot/models/foundational/chronos.py
@@ -114,7 +114,7 @@ class Chronos(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -135,11 +135,12 @@ class Chronos(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned

--- a/timecopilot/models/foundational/timegpt.py
+++ b/timecopilot/models/foundational/timegpt.py
@@ -39,7 +39,7 @@ class TimeGPT(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -60,11 +60,12 @@ class TimeGPT(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -88,6 +89,7 @@ class TimeGPT(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         client = self._get_client()
         fcst_df = client.forecast(
             df=df,

--- a/timecopilot/models/foundational/timesfm.py
+++ b/timecopilot/models/foundational/timesfm.py
@@ -102,7 +102,7 @@ class TimesFM(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -123,11 +123,12 @@ class TimesFM(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -151,6 +152,7 @@ class TimesFM(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         qc = QuantileConverter(level=level, quantiles=quantiles)
         if qc.quantiles is not None and len(qc.quantiles) != len(DEFAULT_QUANTILES_TFM):
             raise ValueError(

--- a/timecopilot/models/foundational/tirex.py
+++ b/timecopilot/models/foundational/tirex.py
@@ -96,7 +96,7 @@ class TiRex(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -117,11 +117,12 @@ class TiRex(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -145,6 +146,7 @@ class TiRex(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         qc = QuantileConverter(level=level, quantiles=quantiles)
         dataset = TimeSeriesDataset.from_df(df, batch_size=self.batch_size)
         fcst_df = dataset.make_future_dataframe(h=h, freq=freq)

--- a/timecopilot/models/foundational/toto.py
+++ b/timecopilot/models/foundational/toto.py
@@ -154,7 +154,7 @@ class Toto(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -175,11 +175,12 @@ class Toto(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -203,6 +204,7 @@ class Toto(Forecaster):
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         qc = QuantileConverter(level=level, quantiles=quantiles)
         dataset = TimeSeriesDataset.from_df(df, batch_size=self.batch_size)
         fcst_df = dataset.make_future_dataframe(h=h, freq=freq)

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -31,7 +31,7 @@ def maybe_convert_col_to_datetime(df: pd.DataFrame, col_name: str) -> pd.DataFra
 class Forecaster:
     alias: str
 
-    def maybe_get_seasonality(self, freq: str) -> int:
+    def _maybe_get_seasonality(self, freq: str) -> int:
         if hasattr(self, "season_length"):
             if self.season_length is not None:
                 return self.season_length

--- a/timecopilot/models/utils/gluonts_forecaster.py
+++ b/timecopilot/models/utils/gluonts_forecaster.py
@@ -95,7 +95,7 @@ class GluonTSForecaster(Forecaster):
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -116,11 +116,11 @@ class GluonTSForecaster(Forecaster):
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If None, the frequency will be inferred from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -149,6 +149,7 @@ class GluonTSForecaster(Forecaster):
                 "Level and quantiles are not supported for GluonTSForecaster yet"
             )
         df = maybe_convert_col_to_float32(df, "y")
+        freq = self._maybe_infer_freq(df, freq)
         gluonts_dataset = PandasDataset.from_long_dataframe(
             df,
             target="y",

--- a/timecopilot/models/utils/parallel_forecaster.py
+++ b/timecopilot/models/utils/parallel_forecaster.py
@@ -4,8 +4,10 @@ from multiprocessing import Pool
 
 import pandas as pd
 
+from .forecaster import Forecaster
 
-class ParallelForecaster:
+
+class ParallelForecaster(Forecaster):
     def _process_group(
         self,
         df: pd.DataFrame,
@@ -50,7 +52,7 @@ class ParallelForecaster:
         self,
         df: pd.DataFrame,
         h: int,
-        freq: str,
+        freq: str | None = None,
         level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
@@ -71,11 +73,12 @@ class ParallelForecaster:
 
             h (int):
                 Forecast horizon specifying how many future steps to predict.
-            freq (str):
+            freq (str, optional):
                 Frequency of the time series (e.g. "D" for daily, "M" for
                 monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
                 pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
-                valid values.
+                valid values. If not provided, the frequency will be inferred
+                from the data.
             level (list[int | float], optional):
                 Confidence levels for prediction intervals, expressed as
                 percentages (e.g. [80, 95]). If provided, the returned
@@ -99,6 +102,7 @@ class ParallelForecaster:
                 For multi-series data, the output retains the same unique
                 identifiers as the input DataFrame.
         """
+        freq = self._maybe_infer_freq(df, freq)
         fcst_df = self._apply_parallel(
             df.groupby("unique_id"),
             self._local_forecast,

--- a/timecopilot/utils/experiment_handler.py
+++ b/timecopilot/utils/experiment_handler.py
@@ -11,7 +11,7 @@ from pydantic_ai import Agent
 from utilsforecast.evaluation import evaluate
 from utilsforecast.losses import _zero_to_nan, mae
 
-from ..models.utils.forecaster import get_seasonality
+from ..models.utils.forecaster import get_seasonality, maybe_infer_freq
 
 warnings.simplefilter(
     action="ignore",
@@ -156,7 +156,7 @@ class ExperimentDatasetParser:
                 seasonality=seasonality,
             )
         # Infer from df if any parameters are still None
-        dataset_params.freq = dataset_params.freq or pd.infer_freq(df["ds"])
+        dataset_params.freq = dataset_params.freq or maybe_infer_freq(df=df, freq=None)
         dataset_params.seasonality = dataset_params.seasonality or get_seasonality(
             dataset_params.freq
         )


### PR DESCRIPTION
this pr makes freq parameter optional. if not passed, it will be infered using the new function `maybe_infer_freq`. a private static method was added to the base `Forecaster` class to make everything in one place. closes \#70.