### PR TITLE
docs: document time copilot forecaster class

### DIFF
--- a/docs/api/forecaster.md
+++ b/docs/api/forecaster.md
@@ -1,0 +1,6 @@
+# `timecopilot.forecaster`
+
+::: timecopilot.forecaster
+    options:
+        members:
+            - TimeCopilotForecaster

--- a/docs/model_hub.md
+++ b/docs/model_hub.md
@@ -1,10 +1,37 @@
 # Time Series Model Hub
 
 
-!!! abstract "Welcome to the Time Series Model Hub!"
-    TimeCopilot provides a unified API for time series forecasting, integrating foundation models, classical statistical models, machine learning, and neural network families of models. This approach lets you experiment, benchmark, and deploy a wide range of forecasting models with minimal code changes, so you can choose the best tool for your data and use case.
+TimeCopilot provides a unified API for time series forecasting, integrating foundation models, classical statistical models, machine learning, and neural network families of models. This approach lets you experiment, benchmark, and deploy a wide range of forecasting models with minimal code changes, so you can choose the best tool for your data and use case.
 
-    Here you'll find all the time series forecasting models available in TimeCopilot, organized by family. Click on any model name to jump to its detailed API documentation.
+Here you'll find all the time series forecasting models available in TimeCopilot, organized by family. Click on any model name to jump to its detailed API documentation.
+
+!!! tip "Forecast multiple models using a unified API"
+
+    With the [TimeCopilotForecaster][timecopilot.forecaster.TimeCopilotForecaster] class, you can generate and cross-validate forecasts using a unified API. Here's an example:
+
+    ```python
+    import pandas as pd
+    from timecopilot.forecaster import TimeCopilotForecaster
+    from timecopilot.models.benchmarks.prophet import Prophet
+    from timecopilot.models.benchmarks.stats import AutoARIMA, SeasonalNaive
+    from timecopilot.models.foundational.toto import Toto
+
+    df = pd.read_csv(
+        "https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv",
+        parse_dates=["ds"],
+    )
+    tcf = TimeCopilotForecaster(
+        models=[
+            AutoARIMA(),
+            SeasonalNaive(),
+            Prophet(),
+            Toto(context_length=256),
+        ]
+    )
+
+    fcst_df = tcf.forecast(df=df, h=12)
+    cv_df = tcf.cross_validation(df=df, h=12)
+    ```
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Forecasting Parameters: forecasting_parameters.md
   - API Reference:
       - api/agent.md
+      - api/forecaster.md
       - api/models/foundational/models.md
       - api/models/benchmarks/stats.md
       - api/models/benchmarks/prophet.md

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -61,7 +61,7 @@ def test_forecaster_forecast_with_level(models):
     level = [80, 90]
     df = generate_series(n_series=n_uids, freq="D", min_length=30)
     forecaster = TimeCopilotForecaster(models=models)
-    fcst_df = forecaster.forecast(df=df, h=2, freq="D", level=level)
+    fcst_df = forecaster.forecast(df=df, h=2, freq="D", level=level)  # type: ignore
     assert len(fcst_df) == 2 * n_uids
     assert len(fcst_df.columns) == 2 + len(models) * (1 + 2 * len(level))
     for model in models:

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -1,10 +1,33 @@
 import pandas as pd
 
-from .models.utils.forecaster import Forecaster, maybe_infer_freq
+from .models.utils.forecaster import Forecaster
 
 
-class TimeCopilotForecaster:
+class TimeCopilotForecaster(Forecaster):
+    """
+    Unified forecaster for multiple time series models.
+
+    This class enables forecasting and cross-validation across a list of models
+    from different families (foundational, statistical, machine learning, neural, etc.)
+    using a single, consistent interface. It is designed to handle panel (multi-series)
+    data and to aggregate results from all models for easy comparison
+    and ensemble workflows.
+
+    The unified API ensures that users can call `forecast` or `cross_validation`
+    once, passing a list of models, and receive merged results for all models.
+    """
+
     def __init__(self, models: list[Forecaster]):
+        """
+        Initialize the TimeCopilotForecaster with a list of models.
+
+        Args:
+            models (list[Forecaster]):
+                List of instantiated model objects from any supported family
+                (foundational, statistical, ML, neural, etc.). Each model must
+                implement the `forecast` and `cross_validation` methods with
+                compatible signatures.
+        """
         self.models = models
 
     def _call_models(
@@ -14,7 +37,7 @@ class TimeCopilotForecaster:
         df: pd.DataFrame,
         h: int,
         freq: str,
-        level: list[int] | None = None,
+        level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
         **kwargs,
     ) -> pd.DataFrame:
@@ -48,11 +71,58 @@ class TimeCopilotForecaster:
         df: pd.DataFrame,
         h: int,
         freq: str | None = None,
-        level: list[int] | None = None,
+        level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
+        """
+        Generate forecasts for one or more time series using all models.
+
+        This method produces point forecasts and, optionally, prediction
+        intervals or quantile forecasts. The input DataFrame can contain one
+        or multiple time series in stacked (long) format.
+
+        Args:
+            df (pd.DataFrame):
+                DataFrame containing the time series to forecast. It must
+                include as columns:
+
+                    - "unique_id": an ID column to distinguish multiple series.
+                    - "ds": a time column indicating timestamps or periods.
+                    - "y": a target column with the observed values.
+
+            h (int):
+                Forecast horizon specifying how many future steps to predict.
+            freq (str, optional):
+                Frequency of the time series (e.g. "D" for daily, "M" for
+                monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
+                pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
+                valid values. If not provided, the frequency will be inferred
+                from the data.
+            level (list[int | float], optional):
+                Confidence levels for prediction intervals, expressed as
+                percentages (e.g. [80, 95]). If provided, the returned
+                DataFrame will include lower and upper interval columns for
+                each specified level.
+            quantiles (list[float], optional):
+                List of quantiles to forecast, expressed as floats between 0
+                and 1. Should not be used simultaneously with `level`. When
+                provided, the output DataFrame will contain additional columns
+                named in the format "model-q-{percentile}", where {percentile}
+                = 100 × quantile value.
+
+        Returns:
+            pd.DataFrame:
+                DataFrame containing forecast results. Includes:
+
+                    - point forecasts for each timestamp, series and model.
+                    - prediction intervals if `level` is specified.
+                    - quantile forecasts if `quantiles` is specified.
+
+                For multi-series data, the output retains the same unique
+                identifiers as the input DataFrame.
+        """
         # infer just once to avoid multiple calls to _maybe_infer_freq
-        freq = maybe_infer_freq(df, freq)
+        freq = self._maybe_infer_freq(df, freq)
         return self._call_models(
             "forecast",
             merge_on=["unique_id", "ds"],
@@ -70,11 +140,65 @@ class TimeCopilotForecaster:
         freq: str | None = None,
         n_windows: int = 1,
         step_size: int | None = None,
-        level: list[int] | None = None,
+        level: list[int | float] | None = None,
         quantiles: list[float] | None = None,
     ) -> pd.DataFrame:
+        """
+        This method splits the time series into multiple training and testing
+        windows and generates forecasts for each window. It enables evaluating
+        forecast accuracy over different historical periods. Supports point
+        forecasts and, optionally, prediction intervals or quantile forecasts.
+
+        Args:
+            df (pd.DataFrame):
+                DataFrame containing the time series to forecast. It must
+                include as columns:
+
+                    - "unique_id": an ID column to distinguish multiple series.
+                    - "ds": a time column indicating timestamps or periods.
+                    - "y": a target column with the observed values.
+
+            h (int):
+                Forecast horizon specifying how many future steps to predict in
+                each window.
+            freq (str, optional):
+                Frequency of the time series (e.g. "D" for daily, "M" for
+                monthly). See [Pandas frequency aliases](https://pandas.pydata.
+                org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+                for valid values. If not provided, the frequency will be inferred
+                from the data.
+            n_windows (int, optional):
+                Number of cross-validation windows to generate. Defaults to 1.
+            step_size (int, optional):
+                Step size between the start of consecutive windows. If None, it
+                defaults to `h`.
+            level (list[int | float], optional):
+                Confidence levels for prediction intervals, expressed as
+                percentages (e.g. [80, 95]). When specified, the output
+                DataFrame includes lower and upper interval columns for each
+                level.
+            quantiles (list[float], optional):
+                Quantiles to forecast, expressed as floats between 0 and 1.
+                Should not be used simultaneously with `level`. If provided,
+                additional columns named "model-q-{percentile}" will appear in
+                the output, where {percentile} is 100 × quantile value.
+
+        Returns:
+            pd.DataFrame:
+                DataFrame containing the forecasts for each cross-validation
+                window. The output includes:
+
+                    - "unique_id" column to indicate the series.
+                    - "ds" column to indicate the timestamp.
+                    - "y" column to indicate the target.
+                    - "cutoff" column to indicate which window each forecast
+                      belongs to.
+                    - point forecasts for each timestamp, series and model.
+                    - prediction intervals if `level` is specified.
+                    - quantile forecasts if `quantiles` is specified.
+        """
         # infer just once to avoid multiple calls to _maybe_infer_freq
-        freq = maybe_infer_freq(df, freq)
+        freq = self._maybe_infer_freq(df, freq)
         return self._call_models(
             "cross_validation",
             merge_on=["unique_id", "ds", "cutoff"],


### PR DESCRIPTION
this pr adds docstring to `TimeCopilotForecaster` and includes a small example in the models hub. closes \#86