### PR TITLE
feat: add tabpfn model

### DIFF
--- a/docs/api/models/foundational/models.md
+++ b/docs/api/models/foundational/models.md
@@ -31,6 +31,11 @@
         members:
             - LagLlama
 
+::: timecopilot.models.foundational.tabpfn
+    options:
+        members:
+            - TabPFN
+
 ::: timecopilot.models.foundational.moirai
     options:
         members:

--- a/docs/model_hub.md
+++ b/docs/model_hub.md
@@ -46,6 +46,7 @@ TimeCopilot provides a unified interface to state-of-the-art foundation models f
 - [TiRex](api/models/foundational/models.md#timecopilot.models.foundational.tirex)
 - [LagLlama](api/models/foundational/models.md#timecopilot.models.foundational.lagllama)
 - [Moirai](api/models/foundational/models.md#timecopilot.models.foundational.moirai)
+- [TabPFN](api/models/foundational/models.md#timecopilot.models.foundational.tabpfn)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "python-dotenv",
   "scipy<=1.15.3",
   "statsforecast",
-  "tabpfn-time-series>=1.0.3",
   "timecopilot-timesfm>=0.1.0",
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "python-dotenv",
   "scipy<=1.15.3",
   "statsforecast",
+  "tabpfn-time-series>=1.0.3 ; python_full_version < '3.13'",
   "timecopilot-timesfm>=0.1.0",
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "python-dotenv",
   "scipy<=1.15.3",
   "statsforecast",
+  "tabpfn-time-series>=1.0.3",
   "timecopilot-timesfm>=0.1.0",
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 import sys
 
+from dotenv import load_dotenv
+
 from timecopilot.agent import MODELS
 from timecopilot.models.foundational.chronos import Chronos
 from timecopilot.models.foundational.toto import Toto
+
+load_dotenv()
 
 benchmark_models = [
     "AutoARIMA",
@@ -17,6 +21,14 @@ if sys.version_info >= (3, 11):
     from timecopilot.models.foundational.tirex import TiRex
 
     models.append(TiRex())
+
+if sys.version_info < (3, 13):
+    from tabpfn_time_series import TabPFNMode
+
+    from timecopilot.models.foundational.tabpfn import TabPFN
+
+    models.append(TabPFN(mode=TabPFNMode.MOCK))
+
 models.extend(
     [
         Chronos(repo_id="amazon/chronos-t5-tiny", alias="Chronos-T5"),

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -23,6 +23,16 @@ def test_tirex_import_fails():
     assert "requires Python >= 3.11" in str(excinfo.value)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="TabPFN requires Python < 3.13",
+)
+def test_tabpfn_import_fails():
+    with pytest.raises(ImportError) as excinfo:
+        from timecopilot.models.foundational.tabpfn import TabPFN  # noqa: F401
+    assert "requires Python < 3.13" in str(excinfo.value)
+
+
 @pytest.mark.parametrize("model", models)
 @pytest.mark.parametrize("freq", ["H", "D", "W-MON", "MS"])
 def test_freq_inferred_correctly(model, freq):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -2,9 +2,15 @@ import sys
 
 import pandas as pd
 import pytest
-from utilsforecast.data import generate_series
+from utilsforecast.data import generate_series as _generate_series
 
 from ..conftest import models
+
+
+def generate_series(n_series, freq, **kwargs):
+    df = _generate_series(n_series, freq, **kwargs)
+    df["unique_id"] = df["unique_id"].astype(str)
+    return df
 
 
 @pytest.mark.skipif(
@@ -25,7 +31,6 @@ def test_freq_inferred_correctly(model, freq):
         n_series,
         freq=freq,
     )
-    df["unique_id"] = df["unique_id"].astype(str)
     fcsts_no_freq = model.forecast(df, h=3)
     fcsts_with_freq = model.forecast(df, h=3, freq=freq)
     cv_no_freq = model.cross_validation(df, h=3)
@@ -53,7 +58,6 @@ def test_correct_forecast_dates(model, freq, h):
         n_series,
         freq=freq,
     )
-    df["unique_id"] = df["unique_id"].astype(str)
     df_test = df.groupby("unique_id").tail(h)
     df_train = df.drop(df_test.index)
     fcst_df = model.forecast(
@@ -77,7 +81,6 @@ def test_cross_validation(model, freq, n_windows):
     h = 12
     n_series = 5
     df = generate_series(n_series, freq=freq, equal_ends=True)
-    df["unique_id"] = df["unique_id"].astype(str)
     cv_df = model.cross_validation(
         df,
         h=h,
@@ -133,7 +136,7 @@ def test_passing_both_level_and_quantiles(model):
 
 @pytest.mark.parametrize("model", models)
 def test_using_quantiles(model):
-    qs = [i * 0.1 for i in range(1, 10)]
+    qs = [round(i * 0.1, 1) for i in range(1, 10)]
     df = generate_series(n_series=3, freq="D")
     fcst_df = model.forecast(
         df=df,
@@ -155,6 +158,9 @@ def test_using_quantiles(model):
         elif "timesfm" in model.alias.lower():
             # TimesFM is a bit more lenient with the monotonicity condition
             assert fcst_df[c1].le(fcst_df[c2]).mean() >= 0.8
+        elif "tabpfn" in model.alias.lower():
+            # we are testing the mock mode, so we don't care about monotonicity
+            continue
         else:
             assert fcst_df[c1].lt(fcst_df[c2]).all()
 
@@ -184,5 +190,8 @@ def test_using_level(model):
         elif "chronos" in model.alias.lower():
             # sometimes it gives this condition
             assert fcst_df[c1].le(fcst_df[c2]).all()
+        elif "tabpfn" in model.alias.lower():
+            # we are testing the mock mode, so we don't care about monotonicity
+            continue
         else:
             assert fcst_df[c1].lt(fcst_df[c2]).all()

--- a/timecopilot/models/foundational/tabpfn.py
+++ b/timecopilot/models/foundational/tabpfn.py
@@ -49,18 +49,20 @@ class TabPFN(Forecaster):
         Args:
             features (list[FeatureGenerator], optional): List of TabPFN-TS feature
                 generators to use for feature engineering. If None, uses
-                [RunningIndexFeature, CalendarFeature, AutoSeasonalFeature] by default.
+                `[RunningIndexFeature(), CalendarFeature(), AutoSeasonalFeature()]`
+                by default.
                 See
-                [TabPFN-TS features](https://github.com/PriorLabs/
-                tabpfn-time-series#feature-engineering).
+                [TabPFN-TS features](https://github.com/PriorLabs/tabpfn-time-series/
+                tree/main/tabpfn_time_series/features).
             context_length (int, optional): Maximum context length (input window size)
                 for the model. Defaults to 4096. Controls how much history is used for
                 each forecast.
             mode (TabPFNMode, optional): Inference mode for TabPFN. If None, uses LOCAL
-                if a GPU is available, otherwise CLIENT (cloud inference via
-                tabpfn-client). See
-                [TabPFN-TS docs](https://github.com/PriorLabs/
-                tabpfn-time-series#inference-modes).
+                (`"tabpfn-local"`) if a GPU is available, otherwise CLIENT (cloud
+                inference via `"tabpfn-client"`). See
+                [TabPFN-TS docs](https://github.com/PriorLabs/tabpfn-time-series/
+                blob/3cd61ad556466de837edd1c6036744176145c024/tabpfn_time_series/
+                predictor.py#L11) for available modes.
             api_key (str, optional): API key for tabpfn-client cloud inference. Required
                 if using CLIENT mode and not already set in the environment.
             alias (str, optional): Name to use for the model in output DataFrames and
@@ -68,8 +70,8 @@ class TabPFN(Forecaster):
 
         Notes:
             - For LOCAL mode, a CUDA-capable GPU is recommended for best performance.
-            - For more information, see the [TabPFN-TS documentation]
-              (https://github.com/PriorLabs/tabpfn-time-series).
+            - For more information, see the [TabPFN-TS documentation](
+            https://github.com/PriorLabs/tabpfn-time-series).
         """
         if features is None:
             features = [

--- a/timecopilot/models/foundational/tabpfn.py
+++ b/timecopilot/models/foundational/tabpfn.py
@@ -1,0 +1,212 @@
+import sys
+from contextlib import contextmanager
+
+if sys.version_info >= (3, 13):
+    raise ImportError("TabPFN requires Python < 3.13")
+
+import numpy as np
+import pandas as pd
+import torch
+from tabpfn_client import set_access_token
+from tabpfn_time_series import (
+    TABPFN_TS_DEFAULT_QUANTILE_CONFIG,
+    FeatureTransformer,
+    TabPFNMode,
+    TabPFNTimeSeriesPredictor,
+    TimeSeriesDataFrame,
+)
+from tabpfn_time_series.data_preparation import generate_test_X
+from tabpfn_time_series.features import (
+    AutoSeasonalFeature,
+    CalendarFeature,
+    RunningIndexFeature,
+)
+from tabpfn_time_series.features.feature_generator_base import (
+    FeatureGenerator,
+)
+
+from ..utils.forecaster import Forecaster, QuantileConverter
+
+
+class TabPFN(Forecaster):
+    """
+    TabPFN is a zero-shot time series forecasting model that frames univariate
+    forecasting as a tabular regression problem using TabPFNv2. It supports both
+    point and probabilistic forecasts, and can incorporate exogenous variables via
+    feature engineering. See the
+    [official repo](https://github.com/PriorLabs/tabpfn-time-series) for more details.
+    """
+
+    def __init__(
+        self,
+        features: list[FeatureGenerator] | None = None,
+        context_length: int = 4096,
+        mode: TabPFNMode | None = None,
+        api_key: str | None = None,
+        alias: str = "TabPFN",
+    ):
+        """
+        Args:
+            features (list[FeatureGenerator], optional): List of TabPFN-TS feature
+                generators to use for feature engineering. If None, uses
+                [RunningIndexFeature, CalendarFeature, AutoSeasonalFeature] by default.
+                See
+                [TabPFN-TS features](https://github.com/PriorLabs/
+                tabpfn-time-series#feature-engineering).
+            context_length (int, optional): Maximum context length (input window size)
+                for the model. Defaults to 4096. Controls how much history is used for
+                each forecast.
+            mode (TabPFNMode, optional): Inference mode for TabPFN. If None, uses LOCAL
+                if a GPU is available, otherwise CLIENT (cloud inference via
+                tabpfn-client). See
+                [TabPFN-TS docs](https://github.com/PriorLabs/
+                tabpfn-time-series#inference-modes).
+            api_key (str, optional): API key for tabpfn-client cloud inference. Required
+                if using CLIENT mode and not already set in the environment.
+            alias (str, optional): Name to use for the model in output DataFrames and
+                logs. Defaults to "TabPFN".
+
+        Notes:
+            - For LOCAL mode, a CUDA-capable GPU is recommended for best performance.
+            - For more information, see the [TabPFN-TS documentation]
+              (https://github.com/PriorLabs/tabpfn-time-series).
+        """
+        if features is None:
+            features = [
+                RunningIndexFeature(),
+                CalendarFeature(),
+                AutoSeasonalFeature(),
+            ]
+        self.feature_transformer = FeatureTransformer(features)
+        self.context_length = context_length
+        if mode is None:
+            mode = TabPFNMode.LOCAL if torch.cuda.is_available() else TabPFNMode.CLIENT
+        if mode == TabPFNMode.CLIENT and api_key is not None:
+            set_access_token(api_key)
+        self.mode = mode
+        self.alias = alias
+
+    @contextmanager
+    def _get_model(self) -> TabPFNTimeSeriesPredictor:
+        model = TabPFNTimeSeriesPredictor(tabpfn_mode=self.mode)
+        try:
+            yield model
+        finally:
+            del model
+            torch.cuda.empty_cache()
+
+    def _forecast(
+        self,
+        model: TabPFNTimeSeriesPredictor,
+        df: pd.DataFrame,
+        h: int,
+        quantiles: list[float] | None,
+    ) -> pd.DataFrame:
+        """handles distinction between quantiles and no quantiles"""
+        renamer = {
+            "unique_id": "item_id",
+            "ds": "timestamp",
+            "y": "target",
+        }
+        tsdf = df.rename(columns=renamer)
+        tsdf = TimeSeriesDataFrame(tsdf.set_index(["item_id", "timestamp"]))
+        if self.context_length > 0:
+            tsdf = tsdf.slice_by_timestep(-self.context_length, None)
+        future_tsdf = generate_test_X(tsdf, h)
+        tsdf, future_tsdf = self.feature_transformer.transform(tsdf, future_tsdf)
+        fcst_df = model.predict(tsdf, future_tsdf)
+        fcst_df = fcst_df.reset_index()
+        re_renamer = {v: k for k, v in renamer.items()}
+        re_renamer["target"] = self.alias
+        fcst_df = fcst_df.rename(columns=re_renamer)
+        if quantiles is None:
+            fcst_df = fcst_df[["unique_id", "ds", self.alias]]
+        else:
+            q_renamer = {
+                q_orig: f"{self.alias}-q-{int(100 * q_user)}"
+                for q_orig, q_user in zip(
+                    TABPFN_TS_DEFAULT_QUANTILE_CONFIG,
+                    quantiles,
+                    strict=True,
+                )
+            }
+            fcst_df = fcst_df.rename(columns=q_renamer)
+        return pd.DataFrame(fcst_df)
+
+    def forecast(
+        self,
+        df: pd.DataFrame,
+        h: int,
+        freq: str | None = None,
+        level: list[int | float] | None = None,
+        quantiles: list[float] | None = None,
+    ) -> pd.DataFrame:
+        """Generate forecasts for time series data using the model.
+
+        This method produces point forecasts and, optionally, prediction
+        intervals or quantile forecasts. The input DataFrame can contain one
+        or multiple time series in stacked (long) format.
+
+        Args:
+            df (pd.DataFrame):
+                DataFrame containing the time series to forecast. It must
+                include as columns:
+
+                    - "unique_id": an ID column to distinguish multiple series.
+                    - "ds": a time column indicating timestamps or periods.
+                    - "y": a target column with the observed values.
+
+            h (int):
+                Forecast horizon specifying how many future steps to predict.
+            freq (str, optional):
+                Frequency of the time series (e.g. "D" for daily, "M" for
+                monthly). See [Pandas frequency aliases](https://pandas.pydata.org/
+                pandas-docs/stable/user_guide/timeseries.html#offset-aliases) for
+                valid values. If not provided, the frequency will be inferred
+                from the data.
+            level (list[int | float], optional):
+                Confidence levels for prediction intervals, expressed as
+                percentages (e.g. [80, 95]). If provided, the returned
+                DataFrame will include lower and upper interval columns for
+                each specified level.
+            quantiles (list[float], optional):
+                List of quantiles to forecast, expressed as floats between 0
+                and 1. Should not be used simultaneously with `level`. When
+                provided, the output DataFrame will contain additional columns
+                named in the format "model-q-{percentile}", where {percentile}
+                = 100 × quantile value.
+
+        Returns:
+            pd.DataFrame:
+                DataFrame containing forecast results. Includes:
+
+                    - point forecasts for each timestamp and series.
+                    - prediction intervals if `level` is specified.
+                    - quantile forecasts if `quantiles` is specified.
+
+                For multi-series data, the output retains the same unique
+                identifiers as the input DataFrame.
+        """
+        freq = self._maybe_infer_freq(df, freq)
+        qc = QuantileConverter(level=level, quantiles=quantiles)
+        if qc.quantiles is not None and not np.allclose(
+            qc.quantiles,
+            TABPFN_TS_DEFAULT_QUANTILE_CONFIG,
+        ):
+            raise ValueError(
+                "TabPFN only supports the default quantiles, "
+                "please use the default quantiles or default level, "
+            )
+        with self._get_model() as model:
+            fcst_df = self._forecast(
+                model,
+                df,
+                h,
+                quantiles=qc.quantiles,
+            )
+        if qc.quantiles is not None:
+            fcst_df = qc.maybe_convert_quantiles_to_level(
+                fcst_df,
+                models=[self.alias],
+            )
+        return fcst_df

--- a/uv.lock
+++ b/uv.lock
@@ -3346,8 +3346,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -3614,6 +3614,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
+]
+
+[[package]]
+name = "password-strength"
+version = "0.0.3.post2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/f1/6165ebcca27fca3f1d63f8c3a45805c2ed8568be4d09219a2aa45e792c14/password_strength-0.0.3.post2.tar.gz", hash = "sha256:bf4df10a58fcd3abfa182367307b4fd7b1cec518121dd83bf80c1c42ba796762", size = 12857, upload-time = "2019-01-04T13:41:29.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/d6/08fd888c980589e4e27c2a4177e972481e8881600138e63afb785fe52630/password_strength-0.0.3.post2-py2.py3-none-any.whl", hash = "sha256:6739357c2863d707b7c7f247ff7c6882a70904a18d12c9aaf98f8b95da176fb9", size = 12167, upload-time = "2019-01-04T13:41:27.497Z" },
 ]
 
 [[package]]
@@ -5150,6 +5162,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sseclient-py"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ed/3df5ab8bb0c12f86c28d0cadb11ed1de44a92ed35ce7ff4fd5518a809325/sseclient-py-1.8.0.tar.gz", hash = "sha256:c547c5c1a7633230a38dc599a21a2dc638f9b5c297286b48b46b935c71fac3e8", size = 7791, upload-time = "2023-09-01T19:39:20.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/58/97655efdfeb5b4eeab85b1fc5d3fa1023661246c2ab2a26ea8e47402d4f2/sseclient_py-1.8.0-py2.py3-none-any.whl", hash = "sha256:4ecca6dc0b9f963f8384e9d7fd529bf93dd7d708144c4fb5da0e0a1a926fee83", size = 8828, upload-time = "2023-09-01T19:39:17.627Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5297,6 +5318,63 @@ wheels = [
 ]
 
 [[package]]
+name = "tabpfn"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops", marker = "python_full_version < '3.13'" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.13'" },
+    { name = "pandas", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "scikit-learn", marker = "python_full_version < '3.13'" },
+    { name = "scipy", marker = "python_full_version < '3.13'" },
+    { name = "torch", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/3a/a195dab09d94766b16837810ae8064079158193532923b96f22a95ed7024/tabpfn-2.1.0.tar.gz", hash = "sha256:bb74732d63a7cd419aaf71fbfeacd12c1a717b0a50342ae17f0736ddbad04dc5", size = 179399, upload-time = "2025-07-09T16:29:15.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d6/dcec05d0e7d9f41d8501167f15c6a046b38e1d90bb34e6c91863915e9fe1/tabpfn-2.1.0-py3-none-any.whl", hash = "sha256:db99d7573626fa47ab27b7f03ee6a7a24e505b1dd6bfab66634fff96c1b0d436", size = 155495, upload-time = "2025-07-09T16:29:13.914Z" },
+]
+
+[[package]]
+name = "tabpfn-client"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "python_full_version < '3.13'" },
+    { name = "omegaconf", marker = "python_full_version < '3.13'" },
+    { name = "pandas", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "password-strength", marker = "python_full_version < '3.13'" },
+    { name = "scikit-learn", marker = "python_full_version < '3.13'" },
+    { name = "sseclient-py", marker = "python_full_version < '3.13'" },
+    { name = "tqdm", marker = "python_full_version < '3.13'" },
+    { name = "xxhash", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/cc/97be739da8d4113c13b8c9fa031908d59210005d38f944e0d678717cf91c/tabpfn_client-0.1.7.tar.gz", hash = "sha256:f8b82318ce22240b7622a05bea2422204ddd5374df335a19284eea0e2252924e", size = 17066065, upload-time = "2025-03-18T12:58:03.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/55/ba50a32b222616eb5653958fc94d91f54ab74109417ada52bb2aecb89a15/tabpfn_client-0.1.7-py3-none-any.whl", hash = "sha256:84245c893b06aa084795c31c04ec3f58186499dfcd7f6f2b8821f9a0a6028136", size = 1902270, upload-time = "2025-03-18T12:57:52.842Z" },
+]
+
+[[package]]
+name = "tabpfn-time-series"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasets", marker = "python_full_version < '3.13'" },
+    { name = "gluonts", marker = "python_full_version < '3.13'" },
+    { name = "pandas", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
+    { name = "statsmodels", marker = "python_full_version < '3.13'" },
+    { name = "tabpfn", marker = "python_full_version < '3.13'" },
+    { name = "tabpfn-client", marker = "python_full_version < '3.13'" },
+    { name = "tqdm", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/8e/82cea00d409a298144b569e4ec4eeb057f89d79c9b2a17d6c5025a7570ac/tabpfn_time_series-1.0.3.tar.gz", hash = "sha256:f0922f73dc4760cc4919b76381443f1b7287f694bb832c5675b5f4f4929fdb6b", size = 468774, upload-time = "2025-07-16T13:21:44.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/bf/13c7fdeeacaf7302b80755e85dcb01d8f47a9ddbac57adef263f0194820c/tabpfn_time_series-1.0.3-py3-none-any.whl", hash = "sha256:0f2436e1a3a87c91315852ab7f8151dcf15c3c2bee4d86e5ee569c0f7ee0f59a", size = 33340, upload-time = "2025-07-16T13:21:43.886Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5360,6 +5438,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "scipy" },
     { name = "statsforecast" },
+    { name = "tabpfn-time-series", marker = "python_full_version < '3.13'" },
     { name = "timecopilot-timesfm" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'" },
     { name = "timecopilot-toto" },
@@ -5393,6 +5472,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "scipy", specifier = "<=1.15.3" },
     { name = "statsforecast" },
+    { name = "tabpfn-time-series", marker = "python_full_version < '3.13'", specifier = ">=1.0.3" },
     { name = "timecopilot-timesfm", specifier = ">=0.1.0" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -3346,8 +3346,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime" },
-    { name = "pyyaml" },
+    { name = "antlr4-python3-runtime", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -3614,18 +3614,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
-]
-
-[[package]]
-name = "password-strength"
-version = "0.0.3.post2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/f1/6165ebcca27fca3f1d63f8c3a45805c2ed8568be4d09219a2aa45e792c14/password_strength-0.0.3.post2.tar.gz", hash = "sha256:bf4df10a58fcd3abfa182367307b4fd7b1cec518121dd83bf80c1c42ba796762", size = 12857, upload-time = "2019-01-04T13:41:29.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/d6/08fd888c980589e4e27c2a4177e972481e8881600138e63afb785fe52630/password_strength-0.0.3.post2-py2.py3-none-any.whl", hash = "sha256:6739357c2863d707b7c7f247ff7c6882a70904a18d12c9aaf98f8b95da176fb9", size = 12167, upload-time = "2019-01-04T13:41:27.497Z" },
 ]
 
 [[package]]
@@ -5162,15 +5150,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sseclient-py"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/ed/3df5ab8bb0c12f86c28d0cadb11ed1de44a92ed35ce7ff4fd5518a809325/sseclient-py-1.8.0.tar.gz", hash = "sha256:c547c5c1a7633230a38dc599a21a2dc638f9b5c297286b48b46b935c71fac3e8", size = 7791, upload-time = "2023-09-01T19:39:20.45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/58/97655efdfeb5b4eeab85b1fc5d3fa1023661246c2ab2a26ea8e47402d4f2/sseclient_py-1.8.0-py2.py3-none-any.whl", hash = "sha256:4ecca6dc0b9f963f8384e9d7fd529bf93dd7d708144c4fb5da0e0a1a926fee83", size = 8828, upload-time = "2023-09-01T19:39:17.627Z" },
-]
-
-[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5318,63 +5297,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tabpfn"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "einops" },
-    { name = "huggingface-hub" },
-    { name = "pandas" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "torch" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3a/a195dab09d94766b16837810ae8064079158193532923b96f22a95ed7024/tabpfn-2.1.0.tar.gz", hash = "sha256:bb74732d63a7cd419aaf71fbfeacd12c1a717b0a50342ae17f0736ddbad04dc5", size = 179399, upload-time = "2025-07-09T16:29:15.51Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d6/dcec05d0e7d9f41d8501167f15c6a046b38e1d90bb34e6c91863915e9fe1/tabpfn-2.1.0-py3-none-any.whl", hash = "sha256:db99d7573626fa47ab27b7f03ee6a7a24e505b1dd6bfab66634fff96c1b0d436", size = 155495, upload-time = "2025-07-09T16:29:13.914Z" },
-]
-
-[[package]]
-name = "tabpfn-client"
-version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "omegaconf" },
-    { name = "pandas" },
-    { name = "password-strength" },
-    { name = "scikit-learn" },
-    { name = "sseclient-py" },
-    { name = "tqdm" },
-    { name = "xxhash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/cc/97be739da8d4113c13b8c9fa031908d59210005d38f944e0d678717cf91c/tabpfn_client-0.1.7.tar.gz", hash = "sha256:f8b82318ce22240b7622a05bea2422204ddd5374df335a19284eea0e2252924e", size = 17066065, upload-time = "2025-03-18T12:58:03.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/55/ba50a32b222616eb5653958fc94d91f54ab74109417ada52bb2aecb89a15/tabpfn_client-0.1.7-py3-none-any.whl", hash = "sha256:84245c893b06aa084795c31c04ec3f58186499dfcd7f6f2b8821f9a0a6028136", size = 1902270, upload-time = "2025-03-18T12:57:52.842Z" },
-]
-
-[[package]]
-name = "tabpfn-time-series"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "datasets" },
-    { name = "gluonts" },
-    { name = "pandas" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "statsmodels" },
-    { name = "tabpfn" },
-    { name = "tabpfn-client" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/8e/82cea00d409a298144b569e4ec4eeb057f89d79c9b2a17d6c5025a7570ac/tabpfn_time_series-1.0.3.tar.gz", hash = "sha256:f0922f73dc4760cc4919b76381443f1b7287f694bb832c5675b5f4f4929fdb6b", size = 468774, upload-time = "2025-07-16T13:21:44.809Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/bf/13c7fdeeacaf7302b80755e85dcb01d8f47a9ddbac57adef263f0194820c/tabpfn_time_series-1.0.3-py3-none-any.whl", hash = "sha256:0f2436e1a3a87c91315852ab7f8151dcf15c3c2bee4d86e5ee569c0f7ee0f59a", size = 33340, upload-time = "2025-07-16T13:21:43.886Z" },
-]
-
-[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5438,7 +5360,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "scipy" },
     { name = "statsforecast" },
-    { name = "tabpfn-time-series" },
     { name = "timecopilot-timesfm" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'" },
     { name = "timecopilot-toto" },
@@ -5472,7 +5393,6 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "scipy", specifier = "<=1.15.3" },
     { name = "statsforecast" },
-    { name = "tabpfn-time-series", specifier = ">=1.0.3" },
     { name = "timecopilot-timesfm", specifier = ">=0.1.0" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -3335,8 +3335,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -3543,6 +3543,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
+]
+
+[[package]]
+name = "password-strength"
+version = "0.0.3.post2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/f1/6165ebcca27fca3f1d63f8c3a45805c2ed8568be4d09219a2aa45e792c14/password_strength-0.0.3.post2.tar.gz", hash = "sha256:bf4df10a58fcd3abfa182367307b4fd7b1cec518121dd83bf80c1c42ba796762", size = 12857, upload-time = "2019-01-04T13:41:29.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/d6/08fd888c980589e4e27c2a4177e972481e8881600138e63afb785fe52630/password_strength-0.0.3.post2-py2.py3-none-any.whl", hash = "sha256:6739357c2863d707b7c7f247ff7c6882a70904a18d12c9aaf98f8b95da176fb9", size = 12167, upload-time = "2019-01-04T13:41:27.497Z" },
 ]
 
 [[package]]
@@ -5077,6 +5089,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sseclient-py"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ed/3df5ab8bb0c12f86c28d0cadb11ed1de44a92ed35ce7ff4fd5518a809325/sseclient-py-1.8.0.tar.gz", hash = "sha256:c547c5c1a7633230a38dc599a21a2dc638f9b5c297286b48b46b935c71fac3e8", size = 7791, upload-time = "2023-09-01T19:39:20.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/58/97655efdfeb5b4eeab85b1fc5d3fa1023661246c2ab2a26ea8e47402d4f2/sseclient_py-1.8.0-py2.py3-none-any.whl", hash = "sha256:4ecca6dc0b9f963f8384e9d7fd529bf93dd7d708144c4fb5da0e0a1a926fee83", size = 8828, upload-time = "2023-09-01T19:39:17.627Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5222,6 +5243,63 @@ wheels = [
 ]
 
 [[package]]
+name = "tabpfn"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "huggingface-hub" },
+    { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/3a/a195dab09d94766b16837810ae8064079158193532923b96f22a95ed7024/tabpfn-2.1.0.tar.gz", hash = "sha256:bb74732d63a7cd419aaf71fbfeacd12c1a717b0a50342ae17f0736ddbad04dc5", size = 179399, upload-time = "2025-07-09T16:29:15.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d6/dcec05d0e7d9f41d8501167f15c6a046b38e1d90bb34e6c91863915e9fe1/tabpfn-2.1.0-py3-none-any.whl", hash = "sha256:db99d7573626fa47ab27b7f03ee6a7a24e505b1dd6bfab66634fff96c1b0d436", size = 155495, upload-time = "2025-07-09T16:29:13.914Z" },
+]
+
+[[package]]
+name = "tabpfn-client"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "omegaconf" },
+    { name = "pandas" },
+    { name = "password-strength" },
+    { name = "scikit-learn" },
+    { name = "sseclient-py" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/cc/97be739da8d4113c13b8c9fa031908d59210005d38f944e0d678717cf91c/tabpfn_client-0.1.7.tar.gz", hash = "sha256:f8b82318ce22240b7622a05bea2422204ddd5374df335a19284eea0e2252924e", size = 17066065, upload-time = "2025-03-18T12:58:03.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/55/ba50a32b222616eb5653958fc94d91f54ab74109417ada52bb2aecb89a15/tabpfn_client-0.1.7-py3-none-any.whl", hash = "sha256:84245c893b06aa084795c31c04ec3f58186499dfcd7f6f2b8821f9a0a6028136", size = 1902270, upload-time = "2025-03-18T12:57:52.842Z" },
+]
+
+[[package]]
+name = "tabpfn-time-series"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasets" },
+    { name = "gluonts" },
+    { name = "pandas" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "statsmodels" },
+    { name = "tabpfn" },
+    { name = "tabpfn-client" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/8e/82cea00d409a298144b569e4ec4eeb057f89d79c9b2a17d6c5025a7570ac/tabpfn_time_series-1.0.3.tar.gz", hash = "sha256:f0922f73dc4760cc4919b76381443f1b7287f694bb832c5675b5f4f4929fdb6b", size = 468774, upload-time = "2025-07-16T13:21:44.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/bf/13c7fdeeacaf7302b80755e85dcb01d8f47a9ddbac57adef263f0194820c/tabpfn_time_series-1.0.3-py3-none-any.whl", hash = "sha256:0f2436e1a3a87c91315852ab7f8151dcf15c3c2bee4d86e5ee569c0f7ee0f59a", size = 33340, upload-time = "2025-07-16T13:21:43.886Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5284,6 +5362,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "scipy" },
     { name = "statsforecast" },
+    { name = "tabpfn-time-series" },
     { name = "timecopilot-timesfm" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'" },
     { name = "timecopilot-toto" },
@@ -5316,6 +5395,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "scipy", specifier = "<=1.15.3" },
     { name = "statsforecast" },
+    { name = "tabpfn-time-series", specifier = ">=1.0.3" },
     { name = "timecopilot-timesfm", specifier = ">=0.1.0" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.1" },


### PR DESCRIPTION
this pr adds the tabpfn model. it is compatible with py<3.13. tests were added as well using its mock mode. docs were also updated to reflect these changes. closes \#92.