### PR TITLE
feat: add fallback model to timecopilot forecaster class

### DIFF
--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -85,6 +85,7 @@ def test_forecaster_forecast_with_quantiles(models):
         for q in quantiles:
             assert f"{model.alias}-q-{int(100 * q)}" in fcst_df.columns
 
+
 def test_forecaster_fallback_model():
     from timecopilot.models.utils.forecaster import Forecaster
 
@@ -136,6 +137,7 @@ def test_forecaster_no_fallback_raises():
     forecaster = TimeCopilotForecaster(models=[FailingModel()])
     with pytest.raises(RuntimeError, match="Intentional failure"):
         forecaster.forecast(df=df, h=2, freq="D")
+
 
 def test_duplicate_aliases_raises_error():
     """Test that TimeCopilotForecaster raises error with duplicate aliases."""

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -87,7 +87,7 @@ class TimeCopilotForecaster(Forecaster):
             fn = getattr(model, attr)
             try:
                 res_df_model = fn(**known_kwargs, **kwargs)
-            except Exception as e:
+            except (ValueError, RuntimeError) as e:
                 if self.fallback_model is not None:
                     fn = getattr(self.fallback_model, attr)
                     res_df_model = fn(**known_kwargs, **kwargs)

--- a/timecopilot/forecaster.py
+++ b/timecopilot/forecaster.py
@@ -90,12 +90,15 @@ class TimeCopilotForecaster(Forecaster):
             except (ValueError, RuntimeError) as e:
                 if self.fallback_model is not None:
                     fn = getattr(self.fallback_model, attr)
-                    res_df_model = fn(**known_kwargs, **kwargs)
-                    cols_map = {
-                        col: col.replace(self.fallback_model.alias, model.alias)
-                        for col in res_df_model.columns
-                    }
-                    res_df_model = res_df_model.rename(columns=cols_map)
+                    try:
+                        res_df_model = fn(**known_kwargs, **kwargs)
+                        cols_map = {
+                            col: col.replace(self.fallback_model.alias, model.alias)
+                            for col in res_df_model.columns
+                        }
+                        res_df_model = res_df_model.rename(columns=cols_map)
+                    except Exception:
+                        raise e
                 else:
                     raise e
             if res_df is None:


### PR DESCRIPTION
this pr adds the option to pass a fallback model to be used when a model fails