### PR TITLE
fix: allow gluonts forecaster to handle more frequencies

### DIFF
--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -66,13 +66,34 @@ def test_freq_inferred_correctly(model, freq):
 
 
 @pytest.mark.parametrize("model", models)
-@pytest.mark.parametrize("freq", ["H", "D", "W-MON", "MS"])
+@pytest.mark.parametrize(
+    "freq",
+    [
+        # gift eval freqs
+        "10S",
+        "10T",
+        "15T",
+        "5T",
+        "A-DEC",
+        "D",
+        "H",
+        "M",
+        "MS",
+        "Q-DEC",
+        "W-FRI",
+        "W-SUN",
+        "W-THU",
+        "W-TUE",
+        "W-WED",
+    ],
+)
 @pytest.mark.parametrize("h", [1, 12])
 def test_correct_forecast_dates(model, freq, h):
     n_series = 5
     df = generate_series(
         n_series,
         freq=freq,
+        max_length=50,
     )
     df_test = df.groupby("unique_id").tail(h)
     df_train = df.drop(df_test.index)

--- a/timecopilot/models/utils/gluonts_forecaster.py
+++ b/timecopilot/models/utils/gluonts_forecaster.py
@@ -16,9 +16,8 @@ from .forecaster import Forecaster, QuantileConverter
 
 def fix_freq(freq: str) -> str:
     # see https://github.com/awslabs/gluonts/pull/2462/files
-    if len(freq) > 1 and freq.endswith("S"):
-        return freq[:-1]
-    return freq
+    replacer = {"MS": "M"}
+    return replacer.get(freq, freq)
 
 
 def maybe_convert_col_to_float32(df: pd.DataFrame, col_name: str) -> pd.DataFrame:


### PR DESCRIPTION
there was a bug trying to use moirai (gluonts forecaster) on data sampled with `10T` frequency. this pr fixes the problem and also adds the complete list of frequencies required by gift eval.