### PR TITLE
fix: use median in gluonts forecaster

### DIFF
--- a/timecopilot/models/utils/gluonts_forecaster.py
+++ b/timecopilot/models/utils/gluonts_forecaster.py
@@ -69,7 +69,7 @@ class GluonTSForecaster(Forecaster):
         model_name: str,
         quantiles: list[float] | None,
     ) -> pd.DataFrame:
-        point_forecast = fcst.mean
+        point_forecast = fcst.median
         h = len(point_forecast)
         dates = pd.date_range(
             fcst.start_date.to_timestamp(),


### PR DESCRIPTION
this pr fixes how gluonts forecaster produced point forecasts. before it used the mean, this pr updates that to use the median instead.