### PR TITLE
fix: timesfm returns correct quantile names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import sys
 from timecopilot.agent import MODELS
 from timecopilot.models.foundational.chronos import Chronos
 from timecopilot.models.foundational.moirai import Moirai
+from timecopilot.models.foundational.timesfm import TimesFM
 from timecopilot.models.foundational.toto import Toto
 
 benchmark_models = [
@@ -10,7 +11,6 @@ benchmark_models = [
     "SeasonalNaive",
     "ZeroModel",
     "ADIDA",
-    "TimesFM",
     "Prophet",
 ]
 models = [MODELS[str_model] for str_model in benchmark_models]
@@ -41,6 +41,10 @@ models.extend(
             batch_size=2,
             repo_id="Salesforce/moirai-moe-1.0-R-small",
             alias="Moirai-MoE",
+        ),
+        TimesFM(
+            repo_id="google/timesfm-1.0-200m-pytorch",
+            context_length=256,
         ),
     ]
 )

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -218,13 +218,12 @@ def test_using_level(model):
     )
     exp_lv_cols = []
     for lv in level:
-        if lv == 0:
-            continue
         exp_lv_cols.extend([f"{model.alias}-lo-{lv}", f"{model.alias}-hi-{lv}"])
     assert len(exp_lv_cols) == len(fcst_df.columns) - 3  # 3 is unique_id, ds, point
     assert all(col in fcst_df.columns for col in exp_lv_cols)
     assert not any(("-q-" in col) for col in fcst_df.columns)
     # test monotonicity of levels
+    exp_lv_cols = exp_lv_cols[2:]  # remove level 0
     for c1, c2 in zip(exp_lv_cols[:-1:2], exp_lv_cols[1::2], strict=False):
         if model.alias == "ZeroModel":
             # ZeroModel is a constant model, so all levels should be the same

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -182,6 +182,7 @@ def test_using_quantiles(model):
         quantiles=qs,
     )
     exp_qs_cols = [f"{model.alias}-q-{int(100 * q)}" for q in qs]
+    assert len(exp_qs_cols) == len(fcst_df.columns) - 3  # 3 is unique_id, ds, point
     assert all(col in fcst_df.columns for col in exp_qs_cols)
     assert not any(("-lo-" in col or "-hi-" in col) for col in fcst_df.columns)
     # test monotonicity of quantiles
@@ -220,6 +221,7 @@ def test_using_level(model):
         if lv == 0:
             continue
         exp_lv_cols.extend([f"{model.alias}-lo-{lv}", f"{model.alias}-hi-{lv}"])
+    assert len(exp_lv_cols) == len(fcst_df.columns) - 3  # 3 is unique_id, ds, point
     assert all(col in fcst_df.columns for col in exp_lv_cols)
     assert not any(("-q-" in col) for col in fcst_df.columns)
     # test monotonicity of levels

--- a/tests/models/utils/test_forecaster.py
+++ b/tests/models/utils/test_forecaster.py
@@ -156,8 +156,6 @@ def test_maybe_convert_quantiles_to_level(n_models, level):
         models=models,
     )
     exp_n_cols = 3 + (1 + len(level) * 2) * n_models
-    if 0 in level:
-        exp_n_cols -= n_models * 2
     assert result_df.shape[1] == exp_n_cols
     for model in models:
         for lv in level:

--- a/timecopilot/models/foundational/timesfm.py
+++ b/timecopilot/models/foundational/timesfm.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 import pandas as pd
 import timesfm
 import torch
-import utilsforecast.processing as ufp
 from timesfm.timesfm_base import DEFAULT_QUANTILES as DEFAULT_QUANTILES_TFM
 
 from ..utils.forecaster import Forecaster, QuantileConverter
@@ -178,12 +177,11 @@ class TimesFM(Forecaster):
                 num_jobs=1,
             )
         if qc.quantiles is not None:
-            for q in qc.quantiles:
-                fcst_df = ufp.assign_columns(
-                    fcst_df,
-                    f"{self.alias}-q-{int(q * 100)}",
-                    fcst_df[f"{self.alias}-q-{q}"],
-                )
+            renamer = {
+                f"{self.alias}-q-{q}": f"{self.alias}-q-{int(q * 100)}"
+                for q in qc.quantiles
+            }
+            fcst_df = fcst_df.rename(columns=renamer)
             fcst_df = qc.maybe_convert_quantiles_to_level(
                 fcst_df,
                 models=[self.alias],

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -356,8 +356,6 @@ class QuantileConverter:
                     if model not in out_cols:
                         out_cols.append(model)
             for lv in self.level:
-                if lv == 0:
-                    continue
                 q_lo, q_hi = self._level_to_quantiles(lv)
                 lo_src = f"{model}-q-{int(q_lo * 100)}"
                 hi_src = f"{model}-q-{int(q_hi * 100)}"


### PR DESCRIPTION
this pr fixes \#130 regarding timesfm returning the quantiles twice with different names. it also adds test to check the correct number of columns is returned in the case of probabilistic forecasts (quantiles and levels) and uses timesfm 1.0 in tests to speed them up.