### PR TITLE
feat: add time copilot async class

### DIFF
--- a/docs/api/agent.md
+++ b/docs/api/agent.md
@@ -4,4 +4,5 @@
     options:
         members:
             - TimeCopilot
+            - TimeCopilotAsync
             - ForecastAgentOutput

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 dev = [
     "pre-commit",
     "pytest",
+    "pytest-asyncio>=1.1.0",
     "pytest-cov",
     "pytest-xdist>=3.8.0",
 ]

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from utilsforecast.data import generate_series
 
 from timecopilot import TimeCopilot
+from timecopilot.agent import TimeCopilotAsync
 
 load_dotenv()
 logfire.configure(send_to_logfire="if-token-present")
@@ -52,11 +53,85 @@ def test_is_queryable():
         llm="openai:gpt-4o-mini",
         retries=3,
     )
-    assert not tc._is_queryable()
+    assert not tc.is_queryable()
     result = tc.forecast(
         df=df,
         query=f"Please forecast the series with a horizon of {h} and frequency D.",
     )
-    assert tc._is_queryable()
+    assert tc.is_queryable()
     result = tc.query("how much will change the series with id 0?")
     print(result.output)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.parametrize("n_series", [1, 2])
+async def test_async_forecast_returns_expected_output(n_series):
+    h = 2
+    df = generate_series(
+        n_series=n_series,
+        freq="D",
+        min_length=30,
+        static_as_categorical=False,
+    )
+    tc = TimeCopilotAsync(
+        llm="openai:gpt-4o-mini",
+        retries=3,
+    )
+    result = await tc.forecast(
+        df=df,
+        query=f"Please forecast the series with a horizon of {h} and frequency D.",
+    )
+    assert len(result.fcst_df) == n_series * h
+    assert result.output.is_better_than_seasonal_naive
+    assert result.output.forecast_analysis is not None
+    assert result.output.reason_for_selection is not None
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_async_is_queryable():
+    h = 2
+    df = generate_series(
+        n_series=2,
+        freq="D",
+        min_length=30,
+        static_as_categorical=False,
+    )
+    tc = TimeCopilotAsync(
+        llm="openai:gpt-4o-mini",
+        retries=3,
+    )
+    assert not tc.is_queryable()
+    await tc.forecast(
+        df=df,
+        query=f"Please forecast the series with a horizon of {h} and frequency D.",
+    )
+    assert tc.is_queryable()
+    answer = await tc.query("how much will change the series with id 0?")
+    print(answer.output)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_async_query_stream():
+    h = 2
+    df = generate_series(
+        n_series=1,
+        freq="D",
+        min_length=30,
+        static_as_categorical=False,
+    )
+    tc = TimeCopilotAsync(
+        llm="openai:gpt-4o-mini",
+        retries=3,
+    )
+    await tc.forecast(
+        df=df,
+        query=f"Please forecast the series with a horizon of {h} and frequency D.",
+    )
+    async with tc.query_stream("What is the forecast for the next 2 days?") as result:
+        # This will yield a StreamedRunResult, which can be streamed for text
+        async for text in result.stream(debounce_by=0.01):
+            print(text, end="", flush=True)
+    print()

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -37,7 +37,6 @@ def test_forecast_returns_expected_output(n_series):
     assert len(result.fcst_df) == n_series * h
     assert result.features_df is not None
     assert result.eval_df is not None
-    assert result.models is not None
     assert result.output.is_better_than_seasonal_naive
     assert result.output.forecast_analysis is not None
     assert result.output.reason_for_selection is not None
@@ -88,7 +87,6 @@ async def test_async_forecast_returns_expected_output(n_series):
     assert len(result.fcst_df) == n_series * h
     assert result.features_df is not None
     assert result.eval_df is not None
-    assert result.models is not None
     assert result.output.is_better_than_seasonal_naive
     assert result.output.forecast_analysis is not None
     assert result.output.reason_for_selection is not None

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -35,6 +35,9 @@ def test_forecast_returns_expected_output(n_series):
         query=f"Please forecast the series with a horizon of {h} and frequency D.",
     )
     assert len(result.fcst_df) == n_series * h
+    assert result.features_df is not None
+    assert result.eval_df is not None
+    assert result.models is not None
     assert result.output.is_better_than_seasonal_naive
     assert result.output.forecast_analysis is not None
     assert result.output.reason_for_selection is not None
@@ -83,6 +86,9 @@ async def test_async_forecast_returns_expected_output(n_series):
         query=f"Please forecast the series with a horizon of {h} and frequency D.",
     )
     assert len(result.fcst_df) == n_series * h
+    assert result.features_df is not None
+    assert result.eval_df is not None
+    assert result.models is not None
     assert result.output.is_better_than_seasonal_naive
     assert result.output.forecast_analysis is not None
     assert result.output.reason_for_selection is not None

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -762,7 +762,7 @@ class TimeCopilotAsync(TimeCopilot):
             The class is not queryable until the `forecast` method has been
             called.
         """
-        # fmt: off
+        # fmt: on
         self._maybe_raise_if_not_queryable()
         async with self.query_agent.run_stream(
             user_prompt=query,

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -656,6 +656,12 @@ class TimeCopilot:
 
 class TimeCopilotAsync(TimeCopilot):
     def __init__(self, **kwargs: Any):
+        """
+        Initialize an asynchronous TimeCopilot agent.
+
+        Inherits from TimeCopilot and provides async methods for
+        forecasting and querying.
+        """
         super().__init__(**kwargs)
 
     async def forecast(
@@ -666,6 +672,37 @@ class TimeCopilotAsync(TimeCopilot):
         seasonality: int | None = None,
         query: str | None = None,
     ) -> AgentRunResult[ForecastAgentOutput]:
+        """
+        Asynchronously generate forecast and analysis for the provided
+        time series data.
+
+        Args:
+            df: The time-series data. Can be one of:
+                - a *pandas* `DataFrame` with at least the columns
+                  `["unique_id", "ds", "y"]`.
+                - a file path or URL pointing to a CSV / Parquet file with the
+                  same columns (it will be read automatically).
+            h: Forecast horizon. Number of future periods to predict. If
+                `None` (default), TimeCopilot will try to infer it from
+                `query` or, as a last resort, default to `2 * seasonality`.
+            freq: Pandas frequency string (e.g. `"H"`, `"D"`, `"MS"`).
+                `None` (default), lets TimeCopilot infer it from the data or
+                the query. See [pandas frequency documentation](https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases).
+            seasonality: Length of the dominant seasonal cycle (expressed in
+                `freq` periods). `None` (default), asks TimeCopilot to infer it via
+                [`get_seasonality`][timecopilot.models.utils.forecaster.get_seasonality].
+            query: Optional natural-language prompt that will be shown to the
+                agent. You can embed `freq`, `h` or `seasonality` here in
+                plain English, they take precedence over the keyword
+                arguments.
+
+        Returns:
+            A result object whose `output` attribute is a fully
+                populated [`ForecastAgentOutput`][timecopilot.agent.ForecastAgentOutput]
+                instance. Use `result.output` to access typed fields or
+                `result.output.prettify()` to print a nicely formatted
+                report.
+        """
         query = f"User query: {query}" if query else None
         experiment_dataset_parser = ExperimentDatasetParser(
             model=self.forecasting_agent.model,
@@ -687,10 +724,94 @@ class TimeCopilotAsync(TimeCopilot):
         return result
 
     @asynccontextmanager
-    async def query_stream(self, query: str):
+    async def query_stream(
+        self,
+        query: str,
+    ) -> AsyncGenerator[AgentRunResult[str], None]:
+        # fmt: off
+        """
+        Asynchronously stream the agent's answer to a follow-up question.
+
+        This method enables chat-like, interactive querying after a forecast 
+        has been run.
+        The agent will use the stored dataframes and the original dataset 
+        to answer the user's
+        question, yielding results as they become available (streaming).
+
+        Args:
+            query (str): The user's follow-up question. This can be about model
+                performance, forecast results, or time series features.
+
+        Returns:
+            AgentRunResult[str]: The agent's answer as a string. Use
+                `result.output` to access the answer.
+
+        Raises:
+            ValueError: If the class is not ready for querying (i.e., forecast
+                has not been run and required dataframes are missing).
+
+        Example:
+            ```python
+            tc = TimeCopilotAsync(llm="openai:gpt-4o")
+            await tc.forecast(df, h=12)
+            async with tc.query_stream("Which model performed best?") as result:
+                async for text in result.stream(debounce_by=0.01):
+                    print(text, end="", flush=True)
+            ```
+        Note:
+            The class is not queryable until the `forecast` method has been
+            called.
+        """
+        # fmt: off
         self._maybe_raise_if_not_queryable()
         async with self.query_agent.run_stream(
             user_prompt=query,
             deps=self.dataset,
         ) as result:
             yield result
+
+    async def query(
+        self,
+        query: str,
+    ) -> AgentRunResult[str]:
+        # fmt: off
+        """
+        Asynchronously ask a follow-up question about the forecast, 
+        model evaluation, or time series features.
+
+        This method enables chat-like, interactive querying after a forecast
+        has been run. The agent will use the stored dataframes (`fcst_df`,
+        `eval_df`, `features_df`) and the original dataset to answer the user's
+        question in a data-driven manner. Typical queries include asking about
+        the best model, forecasted values, or time series characteristics.
+
+        Args:
+            query (str): The user's follow-up question. This can be about model
+                performance, forecast results, or time series features.
+
+        Returns:
+            AgentRunResult[str]: The agent's answer as a string. Use
+                `result.output` to access the answer.
+
+        Raises:
+            ValueError: If the class is not ready for querying (i.e., forecast
+                has not been run and required dataframes are missing).
+
+        Example:
+            ```python
+            tc = TimeCopilotAsync(llm="openai:gpt-4o")
+            await tc.forecast(df, h=12)
+            answer = await tc.query("Which model performed best?")
+            print(answer.output)
+            ```
+        Note:
+            The class is not queryable until the `forecast` method has been
+            called.
+        """
+        # fmt: on
+        self._maybe_raise_if_not_queryable()
+        result = await self.query_agent.run(
+            user_prompt=query,
+            deps=self.dataset,
+        )
+        return result

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "backrefs"
 version = "5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -4686,6 +4695,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5897,6 +5919,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
 ]
@@ -5932,6 +5955,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]


### PR DESCRIPTION
this pr introduces `TimeCopilotAsync` class to handle async routines. the new class supports `forecast` and `query` as async methods and introduces `query_stream` for streaming responses.