### PR TITLE
refactor!: infer params for gift eval when calling evaluate predictor

### DIFF
--- a/docs/api/models/utils/forecaster.md
+++ b/docs/api/models/utils/forecaster.md
@@ -5,3 +5,4 @@
         members:
             - get_seasonality
             - maybe_infer_freq
+            - Forecaster

--- a/docs/changelogs/index.md
+++ b/docs/changelogs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the TimeCopilot Changelog. Here, you will find a comprehensive list of all the changes, updates, and improvements made to the TimeCopilot project. This section is designed to keep you informed about the latest features, bug fixes, and enhancements as we continue to develop and refine the TimeCopilot experience. Stay tuned for regular updates and feel free to explore the details of each release below.
 
-
+- [v0.0.13](v0.0.13.md)
 - [v0.0.12](v0.0.12.md)
 - [v0.0.11](v0.0.11.md)
 - [v0.0.10](v0.0.10.md)

--- a/docs/changelogs/v0.0.13.md
+++ b/docs/changelogs/v0.0.13.md
@@ -1,0 +1,48 @@
+### Features
+
+* **Custom seasonalitites**. Added `custom_seasonalities` argument to [`get_seasonality`][timecopilot.models.utils.forecaster.get_seasonality]. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx).
+    ```python
+    from timecopilot.models.utils.forecaster import get_seasonality
+
+    print(get_seasonality("D", custom_seasonalities={"D": 7}))
+    # 7
+    print(get_seasonality("D")) # default seasonalities are used
+    # 1
+    ```
+
+### Refactor
+
+* **GIFTEval Module**: Refactored the [GIFTEval](https://github.com/SalesforceAIResearch/gift-eval/) module to infer horizon `h` and frequency `freq` directly from the dataset when calling `GIFTEval(...).evaluate_predictor(...)`. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). New usage:
+    ```python
+    import pandas as pd
+    from timecopilot.gift_eval.eval import GIFTEval
+    from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
+    from timecopilot.models.benchmarks import SeasonalNaive
+
+    storage_path = ".pytest_cache/gift_eval"
+    GIFTEval.download_data(storage_path)
+
+    predictor = GluonTSPredictor(
+        # you can use any forecaster from TimeCopilot
+        # and create your own forecaster by subclassing 
+        # [Forecaster][timecopilot.models.utils.forecaster.Forecaster]
+        forecaster=SeasonalNaive(),
+        batch_size=512,
+    )
+    gift_eval = GIFTEval(
+        dataset_name="m4_daily",
+        term="short",
+        output_path="./seasonal_naive",
+        storage_path=storage_path,
+    )
+    gift_eval.evaluate_predictor(
+        predictor,
+        batch_size=512,
+    )
+    eval_df = pd.read_csv("./seasonal_naive/all_results.csv")
+    print(eval_df)
+    ```
+
+---
+
+**Full Changelog**: https://github.com/AzulGarza/timecopilot/compare/v0.0.12...v0.0.13

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - api/gift_eval/gift_eval.md
   - Changelogs:
       - changelogs/index.md
+      - changelogs/v0.0.13.md
       - changelogs/v0.0.12.md
       - changelogs/v0.0.11.md
       - changelogs/v0.0.10.md

--- a/tests/gift_eval/test_evaluation.py
+++ b/tests/gift_eval/test_evaluation.py
@@ -4,9 +4,8 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from gluonts.time_feature import get_seasonality
 
-from timecopilot.gift_eval.eval import QUANTILE_LEVELS, GIFTEval
+from timecopilot.gift_eval.eval import GIFTEval
 from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
 from timecopilot.gift_eval.utils import DATASETS_WITH_TERMS
 from timecopilot.models.benchmarks import SeasonalNaive
@@ -49,22 +48,19 @@ def test_evaluation(
     all_results_df: pd.DataFrame,
     storage_path: Path,
 ):
+    predictor = GluonTSPredictor(
+        forecaster=SeasonalNaive(
+            # alias used by the official evaluation
+            alias="Seasonal_Naive",
+        ),
+        batch_size=512,
+    )
     with tempfile.TemporaryDirectory() as temp_dir:
         gifteval = GIFTEval(
             dataset_name=dataset_name,
             term=term,
             output_path=temp_dir,
             storage_path=storage_path,
-        )
-        predictor = GluonTSPredictor(
-            forecaster=SeasonalNaive(
-                alias="Seasonal_Naive",  # alias used by the official evaluation
-                season_length=get_seasonality(gifteval.dataset.freq),
-            ),
-            h=gifteval.dataset.prediction_length,
-            freq=gifteval.dataset.freq,
-            quantiles=QUANTILE_LEVELS,
-            batch_size=512,
         )
         gifteval.evaluate_predictor(
             predictor,

--- a/tests/models/utils/test_forecaster.py
+++ b/tests/models/utils/test_forecaster.py
@@ -10,6 +10,12 @@ from timecopilot.models.utils.forecaster import (
 )
 
 
+def test_get_seasonality_custom_seasonalities():
+    assert get_seasonality("D", custom_seasonalities={"D": 7}) == 7
+    assert get_seasonality("D", custom_seasonalities={"D": 7}) == 7
+    assert get_seasonality("D") == 1
+
+
 @pytest.mark.parametrize("freq", ["MS", "W-MON", "D"])
 def test_maybe_infer_freq(freq):
     df = generate_series(

--- a/timecopilot/gift_eval/eval.py
+++ b/timecopilot/gift_eval/eval.py
@@ -23,13 +23,12 @@ from huggingface_hub import snapshot_download
 
 from .data import Dataset
 from .gluonts_predictor import GluonTSPredictor
-from .utils import MED_LONG_DATASETS
+from .utils import MED_LONG_DATASETS, QUANTILE_LEVELS
 
 logger = logging.getLogger(__name__)
 
 load_dotenv()
 
-QUANTILE_LEVELS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 METRICS = [
     MSE(forecast_type="mean"),
     MSE(forecast_type=0.5),
@@ -90,27 +89,27 @@ class GIFTEval:
         Example:
             ```python
             import pandas as pd
-            from timecopilot.gift_eval.eval import GIFTEval, QUANTILE_LEVELS
+            from timecopilot.gift_eval.eval import GIFTEval
             from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
             from timecopilot.models.benchmarks import SeasonalNaive
 
             storage_path = "./gift_eval_data"
             GIFTEval.download_data(storage_path)
 
-            gifteval = GIFTEval(
+            predictor = GluonTSPredictor(
+                # you can use any forecaster from TimeCopilot
+                # and create your own forecaster by subclassing 
+                # [Forecaster][timecopilot.models.utils.forecaster.Forecaster]
+                forecaster=SeasonalNaive(),
+                batch_size=512,
+            )
+            gift_eval = GIFTEval(
                 dataset_name="m4_weekly",
                 term="short",
                 output_path="./seasonal_naive",
                 storage_path=storage_path,
             )
-            predictor = GluonTSPredictor(
-                forecaster=SeasonalNaive(),
-                h=gifteval.dataset.prediction_length,
-                freq=gifteval.dataset.freq,
-                quantiles=QUANTILE_LEVELS,
-                batch_size=512,
-            )
-            gifteval.evaluate_predictor(
+            gift_eval.evaluate_predictor(
                 predictor,
                 batch_size=512,
             )

--- a/timecopilot/gift_eval/utils.py
+++ b/timecopilot/gift_eval/utils.py
@@ -1,5 +1,7 @@
 from itertools import product
 
+QUANTILE_LEVELS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+
 SHORT_DATASETS = [
     "m4_yearly",
     "m4_quarterly",

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -17,8 +17,37 @@ from utilsforecast.processing import (
 )
 
 
-def get_seasonality(freq: str) -> int:
-    return _get_seasonality(freq, seasonalities=DEFAULT_SEASONALITIES | {"D": 7})
+def get_seasonality(
+    freq: str,
+    custom_seasonalities: dict[str, int] | None = None,
+) -> int:
+    # fmt: off
+    """
+    Get the seasonality of a frequency.
+
+    Args:
+        freq (str): The frequency to get the seasonality of.
+        custom_seasonalities (dict[str, int] | None): Custom seasonalities to use.
+            If None, the default seasonalities are used.
+
+    Returns:
+        int: The seasonality of the frequency.
+
+    Example:
+        ```python
+        get_seasonality("D", custom_seasonalities={"D": 7})
+        # 7
+        get_seasonality("D") # default seasonalities are used
+        # 1
+        ```
+    """
+    # fmt: on
+    if custom_seasonalities is None:
+        custom_seasonalities = dict()
+    return _get_seasonality(
+        freq,
+        seasonalities=DEFAULT_SEASONALITIES | custom_seasonalities,
+    )
 
 
 def maybe_infer_freq(df: pd.DataFrame, freq: str | None) -> str:


### PR DESCRIPTION
this pr refactors the functionality of `GIFTEval`. it now will infer `h` and `freq` from the evaluatio dataset when `evaluate_predictor` is called. docs and tests were changed to reflect the new behavior. also, the `custom_seasonalities` argument was included to the `get_seasonality` function.