### PR TITLE
refactor!: use median and then isotonic regression in median ensamble

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Run tests 
         run: uv run pytest
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
       - name: Test import class
         run: uv run -- python -c "from timecopilot import TimeCopilot, TimeCopilotForecaster" 

--- a/docs/changelogs/v0.0.13.md
+++ b/docs/changelogs/v0.0.13.md
@@ -10,7 +10,7 @@
     # 1
     ```
 
-* **GIFTEval results concatenation*. Added functionality to concatenate results for different datasets when `GIFTEval(...).evaluate_predictor(...)` is used. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). 
+* **GIFTEval results concatenation**. Added functionality to concatenate results for different datasets when `GIFTEval(...).evaluate_predictor(...)` is used. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). 
     ```python
     import pandas as pd
     from timecopilot.gift_eval.eval import GIFTEval

--- a/docs/changelogs/v0.0.13.md
+++ b/docs/changelogs/v0.0.13.md
@@ -65,7 +65,7 @@
     print(eval_df) # it includes eval just for m4_weekly
     ```
 
-### Refactor
+### Refactorings
 
 * **GIFTEval Module**: Refactored the [GIFTEval](https://github.com/SalesforceAIResearch/gift-eval/) module to infer horizon `h` and frequency `freq` directly from the dataset when calling `GIFTEval(...).evaluate_predictor(...)`. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). New usage:
     ```python
@@ -97,6 +97,8 @@
     eval_df = pd.read_csv("./seasonal_naive/all_results.csv")
     print(eval_df)
     ```
+
+* ***Median ensemble**: Now it applies median plus isotonic regression for probabilistic forecasts. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). 
 
 ---
 

--- a/docs/changelogs/v0.0.13.md
+++ b/docs/changelogs/v0.0.13.md
@@ -10,6 +10,61 @@
     # 1
     ```
 
+* **GIFTEval results concatenation*. Added functionality to concatenate results for different datasets when `GIFTEval(...).evaluate_predictor(...)` is used. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). 
+    ```python
+    import pandas as pd
+    from timecopilot.gift_eval.eval import GIFTEval
+    from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
+    from timecopilot.models.benchmarks import SeasonalNaive
+
+    storage_path = ".pytest_cache/gift_eval"
+    GIFTEval.download_data(storage_path)
+
+    predictor = GluonTSPredictor(
+        forecaster=SeasonalNaive(),
+        batch_size=512,
+    )
+
+    def evaluate_predictor(
+        dataset_name: str,
+        term: str,
+        overwrite_results: bool = False,
+    ):
+        gifteval = GIFTEval(
+            dataset_name=dataset_name,
+            term=term,
+            output_path="./seasonal_naive",
+            storage_path=storage_path,
+        )
+        gifteval.evaluate_predictor(
+            predictor,
+            batch_size=512,
+            overwrite_results=overwrite_results,
+        )
+
+    combinations = [
+        ("m4_weekly", "short"),
+        ("m4_hourly", "short"),
+    ]
+
+    for i, (dataset_name, term) in enumerate(combinations):
+        evaluate_predictor(
+            dataset_name=dataset_name,
+            term=term,
+        )
+    eval_df = pd.read_csv("./seasonal_naive/all_results.csv")
+    print(eval_df) # it includes eval for the two datasets
+
+    # you can use overwrite_results to generate a new file of results 
+    evaluate_predictor(
+        dataset_name="m4_weekly",
+        term="short",
+        overwrite_results=True
+    )
+    eval_df = pd.read_csv("./seasonal_naive/all_results.csv")
+    print(eval_df) # it includes eval just for m4_weekly
+    ```
+
 ### Refactor
 
 * **GIFTEval Module**: Refactored the [GIFTEval](https://github.com/SalesforceAIResearch/gift-eval/) module to infer horizon `h` and frequency `freq` directly from the dataset when calling `GIFTEval(...).evaluate_predictor(...)`. See [#xx](https://github.com/AzulGarza/timecopilot/pull/xx). New usage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.3",
   "timecopilot-uni2ts>=0.1.0",
+  "transformers<4.54",
   "tsfeatures",
   "utilsforecast",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ testpaths = ["tests"]
 addopts = "-m 'not live and not gift_eval' -n auto"
 markers = [
     "live: marks tests that require calls to llm providers",
-    "gift_eval: marks tests related to gift eval"
+    "gift_eval: marks tests related to gift eval results replication"
 ]
 
 [tool.ruff]

--- a/tests/gift_eval/test_gift_eval.py
+++ b/tests/gift_eval/test_gift_eval.py
@@ -1,0 +1,58 @@
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from timecopilot.gift_eval.eval import GIFTEval
+from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
+from timecopilot.models.benchmarks import SeasonalNaive
+
+
+def test_concat_results(storage_path: Path):
+    predictor = GluonTSPredictor(
+        forecaster=SeasonalNaive(),
+        batch_size=512,
+    )
+
+    def _evaluate_predictor(
+        dataset_name: str,
+        term: str,
+        output_path: Path | str,
+        overwrite_results: bool = False,
+    ):
+        gifteval = GIFTEval(
+            dataset_name=dataset_name,
+            term=term,
+            output_path=output_path,
+            storage_path=storage_path,
+        )
+        gifteval.evaluate_predictor(
+            predictor,
+            batch_size=512,
+            overwrite_results=overwrite_results,
+        )
+
+    combinations = [
+        ("m4_weekly", "short"),
+        ("m4_hourly", "short"),
+    ]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for i, (dataset_name, term) in enumerate(combinations):
+            _evaluate_predictor(
+                dataset_name=dataset_name,
+                term=term,
+                output_path=temp_dir,
+            )
+            eval_df = pd.read_csv(Path(temp_dir) / "all_results.csv")
+            print(eval_df)
+            assert len(eval_df) == i + 1
+
+        _evaluate_predictor(
+            dataset_name="m4_hourly",
+            term="short",
+            output_path=temp_dir,
+            overwrite_results=True,
+        )
+        eval_df = pd.read_csv(Path(temp_dir) / "all_results.csv")
+        assert len(eval_df) == 1

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -190,7 +190,7 @@ def test_using_quantiles(model):
         if model.alias == "ZeroModel":
             # ZeroModel is a constant model, so all quantiles should be the same
             assert fcst_df[c1].eq(fcst_df[c2]).all()
-        elif "chronos" in model.alias.lower():
+        elif "chronos" in model.alias.lower() or "median" in model.alias.lower():
             # sometimes it gives this condition
             assert fcst_df[c1].le(fcst_df[c2]).all()
         elif "timesfm" in model.alias.lower():

--- a/timecopilot/gift_eval/eval.py
+++ b/timecopilot/gift_eval/eval.py
@@ -170,6 +170,7 @@ class GIFTEval:
         self,
         predictor: RepresentablePredictor | GluonTSPredictor,
         batch_size: int | None = None,
+        overwrite_results: bool = False,
     ):
         """
         Evaluate a GluonTS predictor on the loaded dataset and save results.
@@ -179,6 +180,8 @@ class GIFTEval:
                 evaluate.
             batch_size (int | None): Batch size for evaluation. If None, uses
                 predictor's default.
+            overwrite_results (bool): Whether to overwrite the existing results CSV
+                file.
         """
         if batch_size is None:
             if isinstance(predictor, GluonTSPredictor):
@@ -246,6 +249,8 @@ class GIFTEval:
         if self.output_path is not None:
             csv_file_path = Path(self.output_path) / "all_results.csv"
             csv_file_path.parent.mkdir(parents=True, exist_ok=True)
+            if csv_file_path.exists() and not overwrite_results:
+                results_df = pd.concat([pd.read_csv(csv_file_path), results_df])
             results_df.to_csv(csv_file_path, index=False)
 
             logger.info(

--- a/uv.lock
+++ b/uv.lock
@@ -5920,6 +5920,7 @@ dependencies = [
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'" },
     { name = "timecopilot-toto" },
     { name = "timecopilot-uni2ts" },
+    { name = "transformers" },
     { name = "tsfeatures" },
     { name = "utilsforecast" },
 ]
@@ -5957,6 +5958,7 @@ requires-dist = [
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.3" },
     { name = "timecopilot-uni2ts", specifier = ">=0.1.0" },
+    { name = "transformers", specifier = "<4.54" },
     { name = "tsfeatures" },
     { name = "utilsforecast" },
 ]


### PR DESCRIPTION
this pr refactors the median ensemble to use median across quantiles and the isotonic regression for probabilistic forecast. docs and tests were updated as needed.