### PR TITLE
fix: update gift eval experiment

### DIFF
--- a/docs/changelogs/v0.0.15.md
+++ b/docs/changelogs/v0.0.15.md
@@ -14,6 +14,10 @@
     print(fcst)
     ```
 
+### Fixes
+
+* **Enhanced GIFT-Eval Experiment**: The experiment now omits models identified as having potential data leakage, following the latest update to the official evaluation criteria. For more information, refer to [#xx](https://github.com/AzulGarza/timecopilot/pull/xx) and [experiments/gift-eval](https://github.com/AzulGarza/timecopilot/tree/main/experiments/gift-eval).
+
 ---
 
 **Full Changelog**: https://github.com/AzulGarza/timecopilot/compare/v0.0.14...v0.0.15

--- a/experiments/gift-eval/README.md
+++ b/experiments/gift-eval/README.md
@@ -6,12 +6,10 @@ TimeCopilot is an open‑source AI agent for time series forecasting that provid
 
 ## Model Description
 
-This ensemble leverages [**TimeCopilot's MedianEnsemble**](https://timecopilot.dev/api/models/ensembles/#timecopilot.models.ensembles.median.MedianEnsemble) feature, which combines five state-of-the-art foundation models:
+This ensemble leverages [**TimeCopilot's MedianEnsemble**](https://timecopilot.dev/api/models/ensembles/#timecopilot.models.ensembles.median.MedianEnsemble) feature, which combines three state-of-the-art foundation models:
 
-- [**Chronos** (Amazon)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.chronos.Chronos).
-- [**Moirai** (Salesforce)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.moirai.Moirai).
-- [**TimesFM** (Google)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.timesfm.TimesFM).
-- [**TiRex** (NX-AI)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.tirex.TiRex).
+- [**Moirai** (Salesforce AI Research)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.moirai.Moirai).
+- [**Sundial** (THUML @ Tsinghua University)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.sundial.Sundial) 
 - [**Toto** (DataDog)](https://timecopilot.dev/api/models/foundational/models/#timecopilot.models.foundational.toto.Toto).
 
 
@@ -57,7 +55,7 @@ make upload-data-to-s3
 Run evaluation on a single dataset locally:
 
 ```bash
-uv run python -m src.run_timecopilot \
+uv run -m src.run_timecopilot \
   --dataset-name "m4_weekly" \
   --term "short" \
   --output-path "./results/timecopilot/" \
@@ -97,3 +95,8 @@ uv run python -m src.download_results
 ```
 
 Results are saved to `results/timecopilot/all_results.csv` in GIFT-Eval format.
+
+
+## Changelog
+
+- **2025-08-05**: GIFT‑Eval recently [enhanced its evaluation dashboard](https://github.com/SalesforceAIResearch/gift-eval/commit/dd4880e24ef2c49fe3a4eb72e601998e4b170b29) with a new flag that identifies models likely affected by data leakage (i.e., having seen parts of the test set during training). While the test set itself hasn’t changed, this new insight helps us better interpret model performance. To keep our results focused on truly unseen data, we’ve excluded any flagged models from this experiment and added the Sundial model to the ensemble. The previous experiment details remain available [here](https://github.com/AzulGarza/timecopilot/tree/v0.0.14/experiments/gift-eval).

--- a/experiments/gift-eval/src/run_timecopilot.py
+++ b/experiments/gift-eval/src/run_timecopilot.py
@@ -6,10 +6,8 @@ import typer
 from timecopilot.gift_eval.eval import GIFTEval
 from timecopilot.gift_eval.gluonts_predictor import GluonTSPredictor
 from timecopilot.models.ensembles.median import MedianEnsemble
-from timecopilot.models.foundational.chronos import Chronos
 from timecopilot.models.foundational.moirai import Moirai
-from timecopilot.models.foundational.timesfm import TimesFM
-from timecopilot.models.foundational.tirex import TiRex
+from timecopilot.models.foundational.sundial import Sundial
 from timecopilot.models.foundational.toto import Toto
 
 logging.basicConfig(level=logging.INFO)
@@ -42,18 +40,13 @@ def run_timecopilot(
     predictor = GluonTSPredictor(
         forecaster=MedianEnsemble(
             models=[
-                Chronos(
-                    repo_id="amazon/chronos-bolt-base",
-                    batch_size=batch_size,
-                ),
                 Moirai(
-                    repo_id="Salesforce/moirai-1.1-R-base",
+                    repo_id="Salesforce/moirai-1.1-R-large",
                     batch_size=batch_size,
                 ),
-                TimesFM(batch_size=batch_size),
-                TiRex(batch_size=batch_size),
+                Sundial(batch_size=batch_size),
                 Toto(
-                    context_length=256,
+                    context_length=1_024,
                     batch_size=batch_size,
                 ),
             ],


### PR DESCRIPTION
recently, the official gift eval dashboard was updated to flag models likely affected by data leakage. this pr updates the experiment to keep results focused on truly unseen data.