### PR TITLE
fix: integrate timesfm changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "statsforecast",
   "tabpfn-time-series>=1.0.3 ; python_full_version < '3.13'",
   "timecopilot-chronos-forecasting>=0.1.0",
-  "timecopilot-timesfm>=0.2.0",
+  "timecopilot-timesfm>=0.2.1",
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.3",
   "timecopilot-uni2ts>=0.1.2 ; python_full_version < '3.14'",

--- a/tests/models/foundation/test_timesfm.py
+++ b/tests/models/foundation/test_timesfm.py
@@ -15,7 +15,7 @@ MODEL_PARAMS = [
     (
         _TimesFMV2_p5,
         [
-            "timecopilot.models.foundation.timesfm.timesfm.TimesFM_2p5_200M_torch",
+            "timecopilot.models.foundation.timesfm.TimesFM_2p5_200M_torch",
         ],
     ),
 ]
@@ -31,7 +31,10 @@ def test_load_model_from_local_path(mocker, model_class, mock_paths):
     local_path = "/fake/local/path"
 
     model_instance = model_class(
-        repo_id=local_path, context_length=64, batch_size=32, alias="test"
+        repo_id=local_path,
+        context_length=64,
+        batch_size=32,
+        alias="test",
     )
 
     with model_instance._get_predictor(prediction_length=12) as p:
@@ -44,9 +47,12 @@ def test_load_model_from_local_path(mocker, model_class, mock_paths):
         expected_path = os.path.join(local_path, "torch_model.ckpt")
         mock_loader[0].assert_called_once_with(path=expected_path)
     elif model_class is _TimesFMV2_p5:
-        assert predictor is mock_loader[0].return_value
-        mock_loader[0].return_value.load_checkpoint.assert_called_once_with(
-            path=os.path.join(local_path, "model.safetensors")
+        expected_predictor = mock_loader[
+            0
+        ].return_value.model.load_checkpoint.return_value
+        assert predictor is expected_predictor
+        mock_loader[0].return_value.model.load_checkpoint.assert_called_once_with(
+            os.path.join(local_path, "model.safetensors")
         )
 
 
@@ -61,7 +67,10 @@ def test_load_model_from_hf_repo(mocker, model_class, mock_paths):
     repo_id = "/fake/google/repo-id"
 
     model_instance = model_class(
-        repo_id=repo_id, context_length=64, batch_size=32, alias="test"
+        repo_id=repo_id,
+        context_length=64,
+        batch_size=32,
+        alias="test",
     )
 
     with model_instance._get_predictor(prediction_length=12) as p:
@@ -74,10 +83,8 @@ def test_load_model_from_hf_repo(mocker, model_class, mock_paths):
         assert predictor is mock_loader[1].return_value
         mock_loader[0].assert_called_once_with(huggingface_repo_id=repo_id)
     elif model_class is _TimesFMV2_p5:
-        assert predictor is mock_loader[0].return_value
-        mock_loader[0].return_value.load_checkpoint.assert_called_once_with(
-            hf_repo_id=repo_id
-        )
+        assert predictor is mock_loader[0].from_pretrained.return_value
+        mock_loader[0].from_pretrained.assert_called_once_with(repo_id)
 
 
 @pytest.mark.parametrize("model_class, _", MODEL_PARAMS)
@@ -91,7 +98,10 @@ def test_model_raises_OSError_on_failed_load(mocker, model_class, _):
     repo_id = "/this-is-a-fake/google/repo-id"
 
     model_instance = model_class(
-        repo_id=repo_id, context_length=64, batch_size=32, alias="test"
+        repo_id=repo_id,
+        context_length=64,
+        batch_size=32,
+        alias="test",
     )
     with (
         pytest.raises(OSError, match="Failed to load model"),

--- a/timecopilot/models/foundation/timesfm.py
+++ b/timecopilot/models/foundation/timesfm.py
@@ -142,14 +142,13 @@ class _TimesFMV2_p5(Forecaster):
         self,
         prediction_length: int,
     ) -> TimesFM_2p5_200M_torch:
-        tfm = TimesFM_2p5_200M_torch()
         # automatically detect the best device
         # https://github.com/AzulGarza/timesfm/blob/b810bbdf9f8a1e66396e7bd5cdb3b005e9116d86/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py#L71
         if os.path.exists(self.repo_id):
             path = os.path.join(self.repo_id, "model.safetensors")
-            tfm.from_pretrained(path)
+            tfm = TimesFM_2p5_200M_torch().model.load_checkpoint(path)
         elif repo_exists(self.repo_id):
-            tfm.from_pretrained(self.repo_id)
+            tfm = TimesFM_2p5_200M_torch.from_pretrained(self.repo_id)
         else:
             raise OSError(
                 f"Failed to load model. Searched for '{self.repo_id}' "

--- a/timecopilot/models/foundation/timesfm.py
+++ b/timecopilot/models/foundation/timesfm.py
@@ -7,6 +7,7 @@ import timesfm
 import timesfm_v1
 import torch
 from huggingface_hub import repo_exists
+from timesfm import TimesFM_2p5_200M_torch
 from timesfm_v1.timesfm_base import DEFAULT_QUANTILES as DEFAULT_QUANTILES_TFM
 from tqdm import tqdm
 
@@ -140,15 +141,15 @@ class _TimesFMV2_p5(Forecaster):
     def _get_predictor(
         self,
         prediction_length: int,
-    ) -> timesfm.TimesFM_2p5_200M_torch:
-        tfm = timesfm.TimesFM_2p5_200M_torch()
+    ) -> TimesFM_2p5_200M_torch:
+        tfm = TimesFM_2p5_200M_torch()
         # automatically detect the best device
         # https://github.com/AzulGarza/timesfm/blob/b810bbdf9f8a1e66396e7bd5cdb3b005e9116d86/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py#L71
         if os.path.exists(self.repo_id):
             path = os.path.join(self.repo_id, "model.safetensors")
-            tfm.load_checkpoint(path=path)
+            tfm.from_pretrained(path)
         elif repo_exists(self.repo_id):
-            tfm.load_checkpoint(hf_repo_id=self.repo_id)
+            tfm.from_pretrained(self.repo_id)
         else:
             raise OSError(
                 f"Failed to load model. Searched for '{self.repo_id}' "
@@ -173,7 +174,7 @@ class _TimesFMV2_p5(Forecaster):
 
     def _predict(
         self,
-        model: timesfm.TimesFM_2p5_200M_torch,
+        model: TimesFM_2p5_200M_torch,
         dataset: TimeSeriesDataset,
         h: int,
     ) -> tuple[np.ndarray, np.ndarray]:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'linux'",
@@ -6853,7 +6853,7 @@ requires-dist = [
     { name = "statsforecast" },
     { name = "tabpfn-time-series", marker = "python_full_version < '3.13'", specifier = ">=1.0.3" },
     { name = "timecopilot-chronos-forecasting", specifier = ">=0.1.0" },
-    { name = "timecopilot-timesfm", specifier = ">=0.2.0" },
+    { name = "timecopilot-timesfm", specifier = ">=0.2.1" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.3" },
     { name = "timecopilot-uni2ts", marker = "python_full_version < '3.14'", specifier = ">=0.1.2" },
@@ -6903,7 +6903,7 @@ wheels = [
 
 [[package]]
 name = "timecopilot-timesfm"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -6921,9 +6921,9 @@ dependencies = [
     { name = "utilsforecast" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/8950544853372341df65745c5c4a8c1d0058a43e06274d7b128597b8c58a/timecopilot_timesfm-0.2.0.tar.gz", hash = "sha256:b425944d34ca0cf5a13c9d3977fa71f7cbbe4c58210614673916715cafa5a420", size = 47450, upload-time = "2025-09-19T01:31:27.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/55/8eb66c4ff18fd7c6270c15ce4c213c21071469ae578c025edf02564bac08/timecopilot_timesfm-0.2.1.tar.gz", hash = "sha256:2d35536896f96d172912469911b18c58df89756106e291c50fd429ba1eebfa34", size = 48322, upload-time = "2025-10-04T20:02:57.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/01/7de21489b39bef007381b08985f700dd5d9c4e0acb25692c10afd736941b/timecopilot_timesfm-0.2.0-py3-none-any.whl", hash = "sha256:ee34652571eaf949786a256b7587fdfcbce1afa825e2067949a624cad3005040", size = 67992, upload-time = "2025-09-19T01:31:26.232Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c2/3283ea4b7498951a33391e4dd9248c82a4d16e4f1eb1a93c3b7a5d87973d/timecopilot_timesfm-0.2.1-py3-none-any.whl", hash = "sha256:ecd2e7bdc5dd29eaf026d96805fe7f9409a470682c3c40a43b12f2d307188722", size = 68860, upload-time = "2025-10-04T20:02:56.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
some changes were introduced in timesfm 2.5 that broke the previous implementation. this pr address them. closes \#232.