### PR TITLE
Llm providers example notebook

### DIFF
--- a/docs/examples/llm-providers.ipynb
+++ b/docs/examples/llm-providers.ipynb
@@ -152,6 +152,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "caf4f0d7",
+   "metadata": {},
+   "source": [
+    "# LLM Providers\n",
+    "\n",
+    "For a full list of LLM providers officially supported by TimeCopilot via Pydantic go to [Pydantic's list of model providers](https://ai.pydantic.dev/models/overview/). Each of those model providers has its own setup section in Pydantic's documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dd7e148c",
    "metadata": {},
    "source": [
@@ -349,7 +359,7 @@
    "id": "93349f86",
    "metadata": {},
    "source": [
-    "## Use TimeCopilot\n",
+    "# Use TimeCopilot\n",
     "\n",
     "After setting up your chosen model and initializing TimeCopilot, you can use it as usual."
    ]

--- a/docs/examples/llm-providers.ipynb
+++ b/docs/examples/llm-providers.ipynb
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "id": "ad21a5f8",
    "metadata": {},
    "outputs": [
@@ -374,26 +374,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<bound method NDFrame.head of          unique_id          ds    y\n",
-      "0    AirPassengers  1949-01-01  112\n",
-      "1    AirPassengers  1949-02-01  118\n",
-      "2    AirPassengers  1949-03-01  132\n",
-      "3    AirPassengers  1949-04-01  129\n",
-      "4    AirPassengers  1949-05-01  121\n",
-      "..             ...         ...  ...\n",
-      "139  AirPassengers  1960-08-01  606\n",
-      "140  AirPassengers  1960-09-01  508\n",
-      "141  AirPassengers  1960-10-01  461\n",
-      "142  AirPassengers  1960-11-01  390\n",
-      "143  AirPassengers  1960-12-01  432\n",
-      "\n",
-      "[144 rows x 3 columns]>\n"
+      "       unique_id          ds    y\n",
+      "0  AirPassengers  1949-01-01  112\n",
+      "1  AirPassengers  1949-02-01  118\n",
+      "2  AirPassengers  1949-03-01  132\n",
+      "3  AirPassengers  1949-04-01  129\n",
+      "4  AirPassengers  1949-05-01  121\n"
      ]
     }
    ],
    "source": [
     "df = pd.read_csv(\"https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv\")\n",
-    "print(df.head)"
+    "print(df.head())"
    ]
   },
   {

--- a/docs/examples/llm-providers.ipynb
+++ b/docs/examples/llm-providers.ipynb
@@ -2,16 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "47b899bc",
-   "metadata": {},
-   "source": [
-    "# Model Compatibility\n",
-    "\n",
-    "TimeCopilot is not compatible with every model, tool use is required a required feature for a model to be compatible with TimeCopilot."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "9c8d5124",
    "metadata": {},
    "source": [
@@ -507,6 +497,52 @@
    ],
    "source": [
     "print(result.fcst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8f591285",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "To calculate the total number of passengers forecasted for the next months using the Prophet model, I will sum up the forecasted values. Here are the forecasted passenger numbers for the next several months:\n",
+      "\n",
+      "1. 466.56\n",
+      "2. 461.04\n",
+      "3. 493.41\n",
+      "4. 492.11\n",
+      "5. 496.45\n",
+      "6. 537.59\n",
+      "7. 577.17\n",
+      "8. 577.60\n",
+      "9. 529.04\n",
+      "10. 493.89\n",
+      "11. 460.03\n",
+      "12. 489.39\n",
+      "\n",
+      "Adding these values gives us a total of approximately \\( 6,074.98 \\) passengers forecasted over the next 12 months.\n",
+      "\n",
+      "This forecast is based on the Prophet model, which has a MASE score of 1.09, indicating its estimation accuracy is relatively good compared to other models.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_result = tc.query(\"how many passengers will be in total in the next months?\")\n",
+    "print(query_result.output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47b899bc",
+   "metadata": {},
+   "source": [
+    "# Model Compatibility\n",
+    "\n",
+    "TimeCopilot is not compatible with every model, tool use is required a required feature for a model to be compatible with TimeCopilot."
    ]
   }
  ],

--- a/docs/examples/llm-providers.ipynb
+++ b/docs/examples/llm-providers.ipynb
@@ -1,0 +1,534 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "47b899bc",
+   "metadata": {},
+   "source": [
+    "# Model Compatibility\n",
+    "\n",
+    "TimeCopilot is not compatible with every model, tool use is required a required feature for a model to be compatible with TimeCopilot."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c8d5124",
+   "metadata": {},
+   "source": [
+    "# Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd1746e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1df75198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from timecopilot import TimeCopilot\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6b73072",
+   "metadata": {},
+   "source": [
+    "# load environment variables\n",
+    "\n",
+    "TimeCopilot uses [Pydantic](https://ai.pydantic.dev/) to interact with LLMs, which has explicit support for [many common model providers](https://ai.pydantic.dev/models/overview/) and implicit support for endpoints using  OpenAI compatible endpoints.\n",
+    "\n",
+    "Configuration will vary slightly depending on which provider is being used. For example, when using OpenAI as your model provider the `OPENAI_API_KEY` environment variable will need to be set to your api key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "babfa336",
+   "metadata": {},
+   "source": [
+    "### directly set the variable with python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d199616",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79021447",
+   "metadata": {},
+   "source": [
+    "### Load from the shell\n",
+    "\n",
+    "This needs to be done before starting your Python process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70f0f3e0",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# bash\n",
+    "export OPENAI_API_KEY=\"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "529e844b",
+   "metadata": {
+    "vscode": {
+     "languageId": "powershell"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# powershell\n",
+    "setx OPENAI_API_KEY \"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5826ba3e",
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "source": [
+    "### store in a .env file and load with [python-dotenv](https://pypi.org/project/python-dotenv/)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "31ac2485",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "# example .env file\n",
+    "OPENAI_API_KEY=\"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e9a17c21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd7e148c",
+   "metadata": {},
+   "source": [
+    "## OpenAI\n",
+    "\n",
+    "### Set the environment variable\n",
+    "\n",
+    "`OPENAI_API_KEY` is the required environment variable for OpenAI. Load it with your preferred method, 3 methods are described above."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "00ea5516",
+   "metadata": {},
+   "source": [
+    "# example .env file\n",
+    "OPENAI_API_KEY=\"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f53d8327",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load the .env file with python-dotenv\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fab1518",
+   "metadata": {},
+   "source": [
+    "### Initialize the forecasting agent\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2ba3ca32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tc = TimeCopilot(\n",
+    "    llm=\"openai:gpt-4o\",\n",
+    "    retries=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3872de9",
+   "metadata": {},
+   "source": [
+    "## Ollama\n",
+    "\n",
+    "### Set the environment variables\n",
+    "\n",
+    "With Ollama the `OLLAMA_BASE_URL` environment variable is required and the `OLLAMA_API_KEY` environment variable may be needed depending on your ollama configuration. If you are running your model locally, you probably don't need the api key.\n",
+    "\n",
+    "You could also use Ollama Cloud, which requires both environment variables with `OLLAMA_BASE_URL` being set to `https://ollama.com/v1`\n",
+    "\n",
+    "The default url when running ollama locally is `http://localhost:11434/v1`.\n",
+    "\n",
+    "Load your environment variables with your preferred method, 3 methods are described above. "
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "44efd7a4",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "# example .env file\n",
+    "\n",
+    "OLLAMA_BASE_URL=\"http://localhost:11434/v1\"\n",
+    "OLLAMA_API_KEY=\"your-new-secret-key\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d85bf485",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load the .env file with python-dotenv\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbf9bebb",
+   "metadata": {},
+   "source": [
+    "### Initialize the forecasting agent\n",
+    "\n",
+    "#### Simple approach (use OllamaProvider by name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64993451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tc = TimeCopilot(\n",
+    "    llm='ollama:gpt-oss:20b',\n",
+    "    retries=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9e86c8b",
+   "metadata": {},
+   "source": [
+    "#### Initialize the model and provider directly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfddbf26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic_ai.models.openai import OpenAIChatModel\n",
+    "from pydantic_ai.providers.ollama import OllamaProvider\n",
+    "\n",
+    "llm = OpenAIChatModel(\n",
+    "    model_name=\"llama3.1:latest\",\n",
+    "    provider=OllamaProvider(base_url=\"http://localhost:11434/v1\"),\n",
+    ")\n",
+    "\n",
+    "tc = TimeCopilot(\n",
+    "    llm=llm,\n",
+    "    retries=3\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ad9dd13",
+   "metadata": {},
+   "source": [
+    "## implicitly supported model providers\n",
+    "\n",
+    "In some cases, there are providers that are compatible with Pydantic that are not on the list of officially supported providers. Generally these will be providers that have an OpenAI style endpoint, but no provider included in Pydantic for simple string initialization.\n",
+    "\n",
+    "In cases like this, you'll initialize the model and provider directly with the appropriate arguments for your setup.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f20cbd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic_ai.models.openai import OpenAIChatModel\n",
+    "from pydantic_ai.providers.openai import OpenAIProvider\n",
+    "\n",
+    "LLM_API_BASE_URL = \"http://127.0.0.1:1234/v1\"\n",
+    "MODEL_NAME = \"gpt-oss-20b\"\n",
+    "API_KEY = \"api-key\"\n",
+    "\n",
+    "model = OpenAIChatModel(\n",
+    "    MODEL_NAME,\n",
+    "    provider=OpenAIProvider(\n",
+    "        base_url=LLM_API_BASE_URL,\n",
+    "        api_key=API_KEY,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "tc = TimeCopilot(\n",
+    "    llm=model,\n",
+    "    retries=3,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93349f86",
+   "metadata": {},
+   "source": [
+    "## Use TimeCopilot\n",
+    "\n",
+    "After setting up your chosen model and initializing TimeCopilot, you can use it as usual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ad21a5f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<bound method NDFrame.head of          unique_id          ds    y\n",
+      "0    AirPassengers  1949-01-01  112\n",
+      "1    AirPassengers  1949-02-01  118\n",
+      "2    AirPassengers  1949-03-01  132\n",
+      "3    AirPassengers  1949-04-01  129\n",
+      "4    AirPassengers  1949-05-01  121\n",
+      "..             ...         ...  ...\n",
+      "139  AirPassengers  1960-08-01  606\n",
+      "140  AirPassengers  1960-09-01  508\n",
+      "141  AirPassengers  1960-10-01  461\n",
+      "142  AirPassengers  1960-11-01  390\n",
+      "143  AirPassengers  1960-12-01  432\n",
+      "\n",
+      "[144 rows x 3 columns]>\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(\"https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv\")\n",
+    "print(df.head)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0adf4e43",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "1it [00:00,  7.48it/s]\n",
+      "1it [00:00, 25.92it/s]\n",
+      "1it [00:00, 251.31it/s]\n",
+      "0it [00:00, ?it/s]15:51:06 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:06 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "1it [00:03,  3.55s/it]\n",
+      "15:51:15 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:15 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "0it [00:00, ?it/s]15:51:18 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:19 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "1it [00:02,  2.97s/it]15:51:21 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:21 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "2it [00:05,  2.97s/it]15:51:24 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:25 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "3it [00:09,  3.03s/it]15:51:28 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:28 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "4it [00:12,  3.05s/it]15:51:31 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:31 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "5it [00:15,  3.06s/it]15:51:34 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:34 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "6it [00:18,  3.07s/it]15:51:37 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:37 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "7it [00:21,  3.12s/it]15:51:40 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:40 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "8it [00:24,  3.13s/it]15:51:43 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:43 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "9it [00:27,  3.09s/it]15:51:46 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:46 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "10it [00:30,  3.06s/it]15:51:49 - cmdstanpy - INFO - Chain [1] start processing\n",
+      "15:51:49 - cmdstanpy - INFO - Chain [1] done processing\n",
+      "11it [00:33,  3.06s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = tc.forecast(df=df, freq=\"MS\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "13902a28",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The time series analysis reveals several key attributes which will guide our model selection:\n",
+      "\n",
+      "1. **Stability (0.933)**: A higher value indicates a relatively stable time series, which is consistent with the seasonal pattern typical in a dataset like AirPassengers.\n",
+      "2. **Unit Root Tests**: The PP test (-6.57) suggests the series is stationary, whereas the KPSS test (2.74) indicates non-stationarity. This mixed signal is somewhat expected in real-world data and suggests models that handle both trends and seasonality might perform well.\n",
+      "3. **Trend and Seasonality**: The series includes a strong trend (0.997) and pronounced seasonal strength (0.982). This points to models that can effectively capture both components, such as Prophet, which explicitly models both trend and seasonality.\n",
+      "4. **Series Length (144)**: A reasonably long series enables the usage of sophisticated models that require more data to perform effectively.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.output.tsfeatures_analysis)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8da4e789",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        unique_id         ds     Prophet\n",
+      "0   AirPassengers 1961-01-01  466.560401\n",
+      "1   AirPassengers 1961-02-01  461.042082\n",
+      "2   AirPassengers 1961-03-01  493.413542\n",
+      "3   AirPassengers 1961-04-01  492.113653\n",
+      "4   AirPassengers 1961-05-01  496.445709\n",
+      "5   AirPassengers 1961-06-01  537.592041\n",
+      "6   AirPassengers 1961-07-01  577.166093\n",
+      "7   AirPassengers 1961-08-01  577.599117\n",
+      "8   AirPassengers 1961-09-01  529.038266\n",
+      "9   AirPassengers 1961-10-01  493.889181\n",
+      "10  AirPassengers 1961-11-01  460.030234\n",
+      "11  AirPassengers 1961-12-01  489.392785\n",
+      "12  AirPassengers 1962-01-01  502.415939\n",
+      "13  AirPassengers 1962-02-01  496.321423\n",
+      "14  AirPassengers 1962-03-01  531.969966\n",
+      "15  AirPassengers 1962-04-01  528.065107\n",
+      "16  AirPassengers 1962-05-01  534.174659\n",
+      "17  AirPassengers 1962-06-01  573.615281\n",
+      "18  AirPassengers 1962-07-01  614.245102\n",
+      "19  AirPassengers 1962-08-01  614.206790\n",
+      "20  AirPassengers 1962-09-01  566.306418\n",
+      "21  AirPassengers 1962-10-01  530.606803\n",
+      "22  AirPassengers 1962-11-01  497.766797\n",
+      "23  AirPassengers 1962-12-01  527.289739\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.fcst_df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "timecopilot",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/llm-providers.ipynb
+++ b/docs/examples/llm-providers.ipynb
@@ -303,7 +303,7 @@
     "from pydantic_ai.providers.ollama import OllamaProvider\n",
     "\n",
     "llm = OpenAIChatModel(\n",
-    "    model_name=\"llama3.1:latest\",\n",
+    "    model_name=\"gpt-oss:20b\",\n",
     "    provider=OllamaProvider(base_url=\"http://localhost:11434/v1\"),\n",
     ")\n",
     "\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Installation: getting-started/installation.md
       - Examples:
           - examples/agent-quickstart.ipynb
+          - examples/llm-providers.ipynb
           - examples/forecaster-quickstart.ipynb
           - examples/anomaly-detection-forecaster-quickstart.ipynb
           - examples/ts-foundation-models-comparison-quickstart.ipynb

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -7,6 +7,7 @@ import pandas as pd
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.models import Model
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -406,7 +407,7 @@ class TimeCopilot:
 
     def __init__(
         self,
-        llm: str,
+        llm: str | Model,
         forecasters: list[Forecaster] | None = None,
         **kwargs: Any,
     ):


### PR DESCRIPTION
For issues #13 #161 #233 since they overlap to some degree.

Set up some basic examples of using non-openai providers that should appear with other examples in the [Getting Started](https://timecopilot.dev/getting-started/) section of the docs. 

Does not address the vllm point of #161, but does explain ollama. Assumes ollama is already setup by/for a user.

Adds Pydantic's [abstract Model](https://github.com/pydantic/pydantic-ai/blob/0e45d0d796545dff6977317bde534d052d6bc647/pydantic_ai_slim/pydantic_ai/models/__init__.py#L338) class to the type hint for the llm argument when initializing a TimeCopilot.
Note: Pydantic's Model is for llm providers, BaseModel seems to be for data validation