### PR TITLE
CI-test docs fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,7 @@ jobs:
         env: 
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
+          OLLAMA_BASE_URL: "URL_PLACEHOLDER"
 
   build-docs:
     name: build docs

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ export OLLAMA_API_KEY='your-api-key'
 ```python
 from timecopilot import TimeCopilot
 
-tc = TimeCopilot(llm="ollama:gpt-oss:20b")
+ollama_tc = TimeCopilot(llm="ollama:gpt-oss:20b")
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -235,24 +235,6 @@ For more details go to the LLM Providers example in [TimeCopilot's documentation
 
 Note: models need support for tool use to function properly with TimeCopilot.
 
-### Ollama example
-
-
-1. load the ollama url into the environment. If your endpoint needs an api key set `OLLAMA_API_KEY` too.
-```bash
-export OLLAMA_BASE_URL='http://localhost:11434/v1'
-# optional
-export OLLAMA_API_KEY='your-api-key'
-```
-
-2. initialize the forecasting agent
-
-```python
-from timecopilot import TimeCopilot
-
-ollama_tc = TimeCopilot(llm="ollama:gpt-oss:20b")
-```
-
 ---
 
 ## Ask about the future

--- a/README.md
+++ b/README.md
@@ -231,22 +231,9 @@ accuracy and reliability surpassing basic seasonal models.'
 
 TimeCopilot uses [Pydantic](https://docs.pydantic.dev/latest/) to make calls to LLM endpoints, so it should be compatible with all endpoints [pydantic supports](https://ai.pydantic.dev/models/overview/). Instructions on using other models/endpoints with Pydantic can be found on the matching pydantic docs page, such as this page for [Google's models](https://ai.pydantic.dev/models/google/#api-key-generative-language-api).
 
+For more details go to the LLM Providers example in [TimeCopilot's documentation](http://timecopilot.dev/examples/llm-providers/).
+
 Note: models need support for tool use to function properly with TimeCopilot.
-
-### Anthropic example
-
-1. load the appropriate api key into the environment
-```bash
-export ANTHROPIC_API_KEY='your-api-key'
-```
-
-2. initialize the forecasting agent
-
-```python
-from timecopilot import TimeCopilot
-
-tc = TimeCopilot(llm="anthropic:claude-sonnet-4-5")
-```
 
 ### Ollama example
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -191,24 +191,6 @@ For more details go to the [LLM Providers example](http://timecopilot.dev/exampl
 
 Note: models need support for tool use to function properly with TimeCopilot.
 
-### Ollama example
-
-
-1. load the ollama url into the environment. If your endpoint needs an api key set `OLLAMA_API_KEY` too.
-```bash
-export OLLAMA_BASE_URL='http://localhost:11434/v1'
-# optional
-export OLLAMA_API_KEY='your-api-key'
-```
-
-2. initialize the forecasting agent
-
-```python
-from timecopilot import TimeCopilot
-
-ollama_tc = TimeCopilot(llm="ollama:gpt-oss:20b")
-```
-
 ---
 
 ## Ask about the future

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -186,22 +186,10 @@ accuracy and reliability surpassing basic seasonal models.'
 
 TimeCopilot uses [Pydantic](https://docs.pydantic.dev/latest/) to make calls to LLM endpoints, so it should be compatible with all endpoints [Pydantic supports](https://ai.pydantic.dev/models/overview/). Instructions on using other models/endpoints with Pydantic can be found on the matching Pydantic docs page, such as this page for [Google's models](https://ai.pydantic.dev/models/google/#api-key-generative-language-api).
 
+
+For more details go to the [LLM Providers example](http://timecopilot.dev/examples/llm-providers/).
+
 Note: models need support for tool use to function properly with TimeCopilot.
-
-### Anthropic example
-
-1. load the appropriate api key into the environment
-```bash
-export ANTHROPIC_API_KEY='your-api-key'
-```
-
-2. initialize the forecasting agent
-
-```python
-from timecopilot import TimeCopilot
-
-tc = TimeCopilot(llm="anthropic:claude-sonnet-4-5")
-```
 
 ### Ollama example
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -206,7 +206,7 @@ export OLLAMA_API_KEY='your-api-key'
 ```python
 from timecopilot import TimeCopilot
 
-tc = TimeCopilot(llm="ollama:gpt-oss:20b")
+ollama_tc = TimeCopilot(llm="ollama:gpt-oss:20b")
 ```
 
 ---


### PR DESCRIPTION
- Remove anthropic README example causing test failures
- add note directing to docs for LLM provider info
- placeholder OLLAMA_BASE_URL, since no calls are being made the placeholder should be enough for the ollama example to pass