### PR TITLE
fix Prophet insufficient data error in detect_anomalies

### DIFF
--- a/tests/models/utils/test_forecaster.py
+++ b/tests/models/utils/test_forecaster.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 from utilsforecast.data import generate_series
 
+from timecopilot.models.prophet import Prophet
 from timecopilot.models.stats import SeasonalNaive
 from timecopilot.models.utils.forecaster import (
     QuantileConverter,
@@ -332,3 +333,16 @@ def test_detect_anomalies_short_series_error():
     )
     with pytest.raises(ValueError, match="Cannot perform anomaly detection"):
         model.detect_anomalies(df, h=5, freq="D")
+
+
+def test_prophet_detect_anomalies_short_series_error():
+    model = Prophet()
+    df = pd.DataFrame(
+        {
+            "unique_id": ["A", "A"],
+            "ds": pd.date_range("2023-01-01", periods=2, freq="D"),
+            "y": [1.0, 2.0],
+        }
+    )
+    with pytest.raises(ValueError, match="Cannot perform anomaly detection"):
+        model.detect_anomalies(df, h=1, freq="D")

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -9,6 +9,7 @@ from gluonts.time_feature.seasonality import (
 from gluonts.time_feature.seasonality import (
     get_seasonality as _get_seasonality,
 )
+from prophet import Prophet as ProphetBase
 from scipy import stats
 from tqdm import tqdm
 from utilsforecast.plotting import plot_series
@@ -348,6 +349,9 @@ class Forecaster:
         min_series_length = df.groupby("unique_id").size().min()
         # we require at least one observation before the first forecast
         max_possible_windows = (min_series_length - 1) // h
+        # 3 row minimum for a df with Prophet
+        if isinstance(self, ProphetBase):
+            max_possible_windows -= 1
         if n_windows is None:
             _n_windows = max_possible_windows
         else:

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -359,7 +359,7 @@ class Forecaster:
             _n_windows = min(n_windows, max_possible_windows)
         if _n_windows < 1:
             # min series length should be 1 higher for Prophet than other models
-            exp_min_series_length = h + 1 if isinstance(self, ProphetBase) else h + 2
+            exp_min_series_length = h + 2 if isinstance(self, ProphetBase) else h + 1
             raise ValueError(
                 f"Cannot perform anomaly detection: series too short. "
                 f"Minimum series length required: {exp_min_series_length}, "

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -305,6 +305,7 @@ class Forecaster:
         Args:
             df (pd.DataFrame):
                 DataFrame containing the time series to detect anomalies.
+                Minimum series length is 1 higher for Prophet than other models.
             h (int, optional):
                 Forecast horizon specifying how many future steps to predict.
                 In each cross validation window. If not provided, the seasonality
@@ -357,9 +358,11 @@ class Forecaster:
         else:
             _n_windows = min(n_windows, max_possible_windows)
         if _n_windows < 1:
+            # min series length should be 1 higher for Prophet than other models
+            exp_min_series_length = h + 1 if isinstance(self, ProphetBase) else h + 2
             raise ValueError(
                 f"Cannot perform anomaly detection: series too short. "
-                f"Minimum series length required: {h + 1}, "
+                f"Minimum series length required: {exp_min_series_length}, "
                 f"actual minimum length: {min_series_length}"
             )
         cv_results = self.cross_validation(

--- a/timecopilot/models/utils/forecaster.py
+++ b/timecopilot/models/utils/forecaster.py
@@ -305,7 +305,8 @@ class Forecaster:
         Args:
             df (pd.DataFrame):
                 DataFrame containing the time series to detect anomalies.
-                Minimum series length is 1 higher for Prophet than other models.
+                Minimum series length is `h + 1` for most models, for Prophet models
+                it is `h + 2`.
             h (int, optional):
                 Forecast horizon specifying how many future steps to predict.
                 In each cross validation window. If not provided, the seasonality
@@ -350,9 +351,9 @@ class Forecaster:
         min_series_length = df.groupby("unique_id").size().min()
         # we require at least one observation before the first forecast
         max_possible_windows = (min_series_length - 1) // h
-        # 3 row minimum for a df with Prophet
+        # Prophet needs a slightly different calculation to guarantee 2 input rows
         if isinstance(self, ProphetBase):
-            max_possible_windows -= 1
+            max_possible_windows = (min_series_length - 2) // h
         if n_windows is None:
             _n_windows = max_possible_windows
         else:


### PR DESCRIPTION
For #258 
In some cases, detect_anomalies can pass a number of windows as an argument to cross_validation that results in a dataframe with a single row being passed to a model. Prophet requires at least 2 rows to function properly.

Decrementing the max possible windows for Prophet fixes that by guaranteeing that the minimum number of rows passed to the model is 2.

There is an implicit minimum of 3 rows in a dataframe used with Prophet for detect_anomalies to function properly. It may be good to make minimums like that explicit.