### PR TITLE
Add lightning_logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # VS Code
 .vscode/
+
+# logs
+lightning_logs/


### PR DESCRIPTION
As far as I'm aware, there's no reason for these logs to be committed.

The logs seem to be coming from pytorch-lightning. 

I haven't checked exactly what action leads to them being generated.