### PR TITLE
docs: fix misspelling in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ nav:
           - examples/ts-foundation-models-comparison-quickstart.ipynb
           - examples/gift-eval.ipynb
           - examples/chronos-family.ipynb
-          - examples/crytpocurrency-quickstart.ipynb
+          - examples/cryptocurrency-quickstart.ipynb
   - Experiments:
       - experiments/gift-eval.md
       - experiments/fev.md


### PR DESCRIPTION
Fix typo in mkdocs example list that caused `build docs` to fail.