### PR TITLE
fix: error in flowstate on single id & h of 1

### DIFF
--- a/timecopilot/models/foundation/flowstate.py
+++ b/timecopilot/models/foundation/flowstate.py
@@ -193,7 +193,10 @@ class FlowState(Forecaster):
             for batch in tqdm(dataset)
         ]  # list of tuples
         fcsts_mean_tp, fcsts_quantiles_tp = zip(*fcsts, strict=False)
-        fcsts_mean_np = np.concatenate(fcsts_mean_tp)
+        # handle single item forecast output
+        fcsts_mean_np = fcsts_mean_tp[0]
+        if fcsts_mean_tp[0].shape != tuple():
+            fcsts_mean_np = np.concatenate(fcsts_mean_tp)
         if quantiles is not None:
             fcsts_quantiles_np = np.concatenate(fcsts_quantiles_tp)
         else:


### PR DESCRIPTION
Fixes an error that occurred with flowstate when using data with a single id and an h of 1.

The error can be created with the following code.

```Python
import nest_asyncio
nest_asyncio.apply()

import pandas as pd

import timecopilot
from timecopilot.models.foundation.flowstate import FlowState

flowstate_model = FlowState()

forecaster = timecopilot.TimeCopilotForecaster(
    models=[
        flowstate_model
    ]
)

flowstate_df = df = pd.read_csv("https://timecopilot.s3.amazonaws.com/public/data/air_passengers.csv",
                                parse_dates=["ds"])
# flowstate_df = pd.read_csv(
#     "https://timecopilot.s3.amazonaws.com/public/data/the_anomaly_tour.csv",
#     parse_dates=["ds"],
# )


forecaster.forecast(
    df=flowstate_df,
    h=1
)
```