### PR TITLE
ci: clear space in action runner and cache hf models

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,24 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Free disk space in action runner
+        # there are a couple different actions that can do this
+        # https://github.com/BRAINSia/free-disk-space
+        # https://github.com/endersonmenezes/free-disk-space
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          rm_cmd: "rmz"
+          rmz_version: "3.1.1"
+
+      - name: Cache HuggingFace Models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub/
+          key: ${{ Runner.os }}-huggingface-${{ hashFiles('**/tests/') }}
+
       - name: Run tests 
         run: uv run pytest
         env:


### PR DESCRIPTION
Action Runners for "Test on {python-version}" have been appearing to stall and fail without providing a clear explanation or error message. When testing out caching of the HuggingFace models, an error message was thrown when trying to save the cache about a lack of storage space. After testing, clearing out some storage space in the action runner before running the tests seems to fix the inconsistency and frequent failures in CI.

The files that are cleared out are for Android, Dotnet, and Haskell.

If it's possible to use a standard action runner with a lighter docker image, that may be a better solution.

Larger runners don't seem to provide a consistent speed increase currently. The large cpu runner can range in time between 11 minutes and 2 hours. The GPU runner is having issues with cuda/torch setup.