### PR TITLE
Bump Hugginface_hub version to v0.36.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 dependencies = [
   "fire",
   "gluonts[torch]",
-  "huggingface-hub>=0.34.4",
+  "huggingface-hub>=0.36.0",
   "lightgbm>=4.6.0",
   "logfire>=4.7.0",
   "mlforecast>=1.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2019,7 +2019,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.35.3"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2031,9 +2031,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/7e/a0a97de7c73671863ca6b3f61fa12518caf35db37825e43d63a70956738c/huggingface_hub-0.35.3.tar.gz", hash = "sha256:350932eaa5cc6a4747efae85126ee220e4ef1b54e29d31c3b45c5612ddf0b32a", size = 461798, upload-time = "2025-09-29T14:29:58.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl", hash = "sha256:0e3a01829c19d86d03793e4577816fe3bdfc1602ac62c7fb220d593d351224ba", size = 564262, upload-time = "2025-09-29T14:29:55.813Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
 ]
 
 [package.optional-dependencies]
@@ -6879,7 +6879,7 @@ docs = [
 requires-dist = [
     { name = "fire" },
     { name = "gluonts", extras = ["torch"] },
-    { name = "huggingface-hub", specifier = ">=0.34.4" },
+    { name = "huggingface-hub", specifier = ">=0.36.0" },
     { name = "lightgbm", specifier = ">=4.6.0" },
     { name = "logfire", specifier = ">=4.7.0" },
     { name = "mlforecast", specifier = ">=1.0.2" },


### PR DESCRIPTION
v0.36.0 is the latest version compatible with our other dependencies.

To move above huggingface_hub v1 `transformers` would need to be bumped to v5, which [is not supported yet by Chronos](https://github.com/amazon-science/chronos-forecasting/pull/416). When that change is merged into Chronos, the [timecopilot fork of Chronos](https://github.com/AzulGarza/chronos-forecasting) will need to be updated.