### PR TITLE
docs: add newsletter signup and Talk to Us button

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,3 +13,30 @@ hide:
 </style>
 
 --8<-- "README.md"
+
+<div class="newsletter-signup">
+  <h2>Stay Updated</h2>
+  <p>Get updates on new features and forecasting insights. No spam, unsubscribe anytime.</p>
+  <form class="newsletter-form" id="newsletter-form">
+    <input type="email" name="email" placeholder="Your email address" required />
+    <button type="submit">Subscribe</button>
+  </form>
+  <p class="newsletter-thanks" id="newsletter-thanks" style="display:none;">Thanks for subscribing!</p>
+</div>
+
+<script>
+document.getElementById("newsletter-form").addEventListener("submit", function(e) {
+  e.preventDefault();
+  var form = e.target;
+  fetch("https://formspree.io/f/xvzbzjkk", {
+    method: "POST",
+    body: new FormData(form),
+    headers: { "Accept": "application/json" }
+  }).then(function(response) {
+    if (response.ok) {
+      form.style.display = "none";
+      document.getElementById("newsletter-thanks").style.display = "block";
+    }
+  });
+});
+</script>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+{{ super() }}
+<a class="talk-to-us" href="https://cal.com/team/timecopilot/azul-renee-seb" target="_blank" rel="noopener">Talk to Us</a>
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,6 +19,98 @@
 
   --md-typeset-color: #c9d1d9;
   --md-typeset-a-color: var(--md-primary-fg-color);
+}
+
+/* Talk to Us floating button */
+.talk-to-us {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--md-primary-fg-color);
+  color: #fff !important;
+  border-radius: 50px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 4px 12px rgba(32, 128, 255, 0.4);
+  z-index: 100;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.talk-to-us:hover {
+  background: var(--md-primary-fg-color--dark);
+  box-shadow: 0 6px 16px rgba(32, 128, 255, 0.5);
+}
+
+/* Newsletter signup */
+.newsletter-signup {
+  margin-top: 3rem;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  background: #f0f4ff;
+  border: 1px solid #d0dfff;
+}
+
+.newsletter-signup h2 {
+  margin-top: 0;
+}
+
+.newsletter-signup p {
+  opacity: 0.8;
+}
+
+.newsletter-form {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.newsletter-form input[type="email"] {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: 1px solid #c0cfee;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.newsletter-form input[type="email"]:focus {
+  border-color: var(--md-primary-fg-color);
+}
+
+.newsletter-form button {
+  padding: 0.6rem 1.5rem;
+  background: var(--md-primary-fg-color);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.newsletter-form button:hover {
+  background: var(--md-primary-fg-color--dark);
+}
+
+.newsletter-thanks {
+  color: var(--md-primary-fg-color);
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+[data-md-color-scheme="slate"] .newsletter-signup {
+  background: #161b22;
+  border-color: #30363d;
+}
+
+[data-md-color-scheme="slate"] .newsletter-form input[type="email"] {
+  background: #0d1117;
+  border-color: #30363d;
+  color: #c9d1d9;
 } 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
 
 theme:
   name: "material"
+  custom_dir: docs/overrides
   logo: https://timecopilot.s3.amazonaws.com/public/logos/logo-white.svg
   favicon: https://timecopilot.s3.amazonaws.com/public/logos/favicon-white.svg
   palette:


### PR DESCRIPTION
## Summary
- Add a newsletter signup form (Formspree) at the bottom of the homepage with inline thank-you message
- Add a floating "Talk to Us" button linking to cal.com booking page, visible on all pages via theme override
- Add supporting CSS for both components with light/dark mode support

## Test plan
- [ ] Run `mkdocs serve` and verify the newsletter form appears at the bottom of the homepage
- [ ] Submit a test email and confirm inline "Thanks for subscribing!" message (no redirect)
- [ ] Verify the "Talk to Us" button appears on all pages and links to cal.com
- [ ] Toggle light/dark mode and confirm both components render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)