### PR TITLE
Fix slow pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ requires = ["hatchling"]
 dev = [
   "mktestdocs>=0.2.5",
   "pre-commit",
-  "pytest",
   "pytest-asyncio>=1.1.0",
   "pytest-cov",
   "pytest-mock>=3.15.1",
   "pytest-rerunfailures>=15.1",
   "pytest-xdist>=3.8.0",
+  "pytest>=8.4.2",
   "s3fs>=2025.3.0",
   "sktime>=0.40.1",
 ]
@@ -48,33 +48,57 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 # NOTE: dependency version notes
-# - huggingface-hub can't bump to v1 until transformers bumps to v5
+# - huggingface-hub can't bump to v1+ until transformers bumps to v5
+# - lightning and pytorch-lightning are the same library
+# NOTE: dependencies pinned for faster pip installs
+# versions chosen from uv's dependency resolution
+# list:
+# accelerate arch black datasets fsspec hydra-core lightning lightning-utilities matplotlib opentelemetry-api opentelemetry-instrumentation opentelemetry-sdk optuna plotly pytorch-lightning ray statsforecast tensorboard torchmetrics wandb
 dependencies = [
+  "accelerate>=1.10.1",
+  "arch>=7.2.0",
+  "black>=25.9.0",
+  "datasets>=4.1.1",
   "fire",
+  "fsspec>=2025.9.0",
   "gluonts[torch]",
-  "huggingface-hub>=0.36.0,<1.0",
+  "huggingface-hub>=0.36.2,<1.0",
+  "hydra-core>=1.3.2",
   "lightgbm>=4.6.0",
-  "logfire>=4.7.0",
+  "lightning-utilities>=0.15.2",
+  "lightning==2.4.0",
+  "logfire==4.11.0",
+  "matplotlib>=3.10.6",
   "mlforecast>=1.0.2",
   "neuralforecast>=3.0.2",
-  "nixtla>=0.6.6",
+  "nixtla>=0.7.0",
   "openai>=1.99.7",
+  "opentelemetry-api==1.37.0",
+  "opentelemetry-instrumentation>=0.58b0",
+  "opentelemetry-sdk==1.37.0",
+  "optuna>=4.5.0",
   "pandas>=2.2.0 ; python_full_version >= '3.13'",
+  "plotly>=6.3.1",
   "prophet>=1.1.7",
   "pydantic-ai>=0.7.0",
+  "pytorch-lightning==2.4.0",
+  "ray==2.49.2",
   "scipy<=1.15.3",
-  "statsforecast",
+  "statsforecast>=2.0.2",
   "tabpfn-time-series==1.0.3 ; python_full_version < '3.13'",
+  "tensorboard>=2.20.0",
   "timecopilot-chronos-forecasting>=0.2.0",
   "timecopilot-granite-tsfm>=0.1.1",
   "timecopilot-timesfm>=0.2.1",
   "timecopilot-tirex>=0.1.0 ; python_full_version >= '3.11'",
   "timecopilot-toto>=0.1.5",
   "timecopilot-uni2ts>=0.1.2 ; python_full_version < '3.14'",
+  "torchmetrics>=1.8.2",
   "transformers==4.40.1 ; python_full_version < '3.13'",
   "transformers>=4.48,<5 ; python_full_version >= '3.13'",
-  "tsfeatures",
+  "tsfeatures>=0.4.5",
   "utilsforecast[plotting]>=0.2.15",
+  "wandb==0.22.1",
 ]
 description = "The GenAI Forecasting Agent · LLMs × Time Series Foundation Models"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,12 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+# NOTE: dependency version notes
+# - huggingface-hub can't bump to v1 until transformers bumps to v5
 dependencies = [
   "fire",
   "gluonts[torch]",
-  "huggingface-hub>=0.36.0",
+  "huggingface-hub>=0.36.0,<1.0",
   "lightgbm>=4.6.0",
   "logfire>=4.7.0",
   "mlforecast>=1.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1848,7 +1848,7 @@ name = "grpcio"
 version = "1.75.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/f7/8963848164c7604efb3a3e6ee457fdb3a469653e19002bd24742473254f8/grpcio-1.75.1.tar.gz", hash = "sha256:3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2", size = 12731327, upload-time = "2025-09-26T09:03:36.887Z" }
 wheels = [
@@ -2019,7 +2019,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -2031,9 +2031,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [package.optional-dependencies]
@@ -2049,9 +2049,9 @@ name = "hydra-core"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version < '3.14'" },
-    { name = "omegaconf", marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
@@ -6760,17 +6760,17 @@ name = "tensorboard"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "python_full_version < '3.14'" },
-    { name = "grpcio", marker = "python_full_version < '3.14'" },
-    { name = "markdown", marker = "python_full_version < '3.14'" },
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pillow", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "setuptools", marker = "python_full_version < '3.14'" },
-    { name = "tensorboard-data-server", marker = "python_full_version < '3.14'" },
-    { name = "werkzeug", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/tensorboard-2.20.0-py3-none-any.whl", hash = "sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6", size = 5525680, upload-time = "2025-07-17T19:20:49.638Z" },
@@ -6824,31 +6824,50 @@ name = "timecopilot"
 version = "0.0.23"
 source = { editable = "." }
 dependencies = [
+    { name = "accelerate" },
+    { name = "arch" },
+    { name = "black" },
+    { name = "datasets" },
     { name = "fire" },
+    { name = "fsspec" },
     { name = "gluonts", extra = ["torch"] },
     { name = "huggingface-hub" },
+    { name = "hydra-core" },
     { name = "lightgbm" },
+    { name = "lightning" },
+    { name = "lightning-utilities" },
     { name = "logfire" },
+    { name = "matplotlib" },
     { name = "mlforecast" },
     { name = "neuralforecast" },
     { name = "nixtla" },
     { name = "openai" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "optuna" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "plotly" },
     { name = "prophet" },
     { name = "pydantic-ai" },
+    { name = "pytorch-lightning" },
+    { name = "ray" },
     { name = "scipy" },
     { name = "statsforecast" },
     { name = "tabpfn-time-series", marker = "python_full_version < '3.13'" },
+    { name = "tensorboard" },
     { name = "timecopilot-chronos-forecasting" },
     { name = "timecopilot-granite-tsfm" },
     { name = "timecopilot-timesfm" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'" },
     { name = "timecopilot-toto" },
     { name = "timecopilot-uni2ts", marker = "python_full_version < '3.14'" },
+    { name = "torchmetrics" },
     { name = "transformers", version = "4.40.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "transformers", version = "4.57.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "tsfeatures" },
     { name = "utilsforecast", extra = ["plotting"] },
+    { name = "wandb" },
 ]
 
 [package.dev-dependencies]
@@ -6877,38 +6896,57 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", specifier = ">=1.10.1" },
+    { name = "arch", specifier = ">=7.2.0" },
+    { name = "black", specifier = ">=25.9.0" },
+    { name = "datasets", specifier = ">=4.1.1" },
     { name = "fire" },
+    { name = "fsspec", specifier = ">=2025.9.0" },
     { name = "gluonts", extras = ["torch"] },
-    { name = "huggingface-hub", specifier = ">=0.36.0,<1.0" },
+    { name = "huggingface-hub", specifier = ">=0.36.2,<1.0" },
+    { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "lightgbm", specifier = ">=4.6.0" },
-    { name = "logfire", specifier = ">=4.7.0" },
+    { name = "lightning", specifier = "==2.4.0" },
+    { name = "lightning-utilities", specifier = ">=0.15.2" },
+    { name = "logfire", specifier = "==4.11.0" },
+    { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "mlforecast", specifier = ">=1.0.2" },
     { name = "neuralforecast", specifier = ">=3.0.2" },
-    { name = "nixtla", specifier = ">=0.6.6" },
+    { name = "nixtla", specifier = ">=0.7.0" },
     { name = "openai", specifier = ">=1.99.7" },
+    { name = "opentelemetry-api", specifier = "==1.37.0" },
+    { name = "opentelemetry-instrumentation", specifier = ">=0.58b0" },
+    { name = "opentelemetry-sdk", specifier = "==1.37.0" },
+    { name = "optuna", specifier = ">=4.5.0" },
     { name = "pandas", marker = "python_full_version >= '3.13'", specifier = ">=2.2.0" },
+    { name = "plotly", specifier = ">=6.3.1" },
     { name = "prophet", specifier = ">=1.1.7" },
     { name = "pydantic-ai", specifier = ">=0.7.0" },
+    { name = "pytorch-lightning", specifier = "==2.4.0" },
+    { name = "ray", specifier = "==2.49.2" },
     { name = "scipy", specifier = "<=1.15.3" },
-    { name = "statsforecast" },
+    { name = "statsforecast", specifier = ">=2.0.2" },
     { name = "tabpfn-time-series", marker = "python_full_version < '3.13'", specifier = "==1.0.3" },
+    { name = "tensorboard", specifier = ">=2.20.0" },
     { name = "timecopilot-chronos-forecasting", specifier = ">=0.2.0" },
     { name = "timecopilot-granite-tsfm", specifier = ">=0.1.1" },
     { name = "timecopilot-timesfm", specifier = ">=0.2.1" },
     { name = "timecopilot-tirex", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "timecopilot-toto", specifier = ">=0.1.5" },
     { name = "timecopilot-uni2ts", marker = "python_full_version < '3.14'", specifier = ">=0.1.2" },
+    { name = "torchmetrics", specifier = ">=1.8.2" },
     { name = "transformers", marker = "python_full_version < '3.13'", specifier = "==4.40.1" },
     { name = "transformers", marker = "python_full_version >= '3.13'", specifier = ">=4.48,<5" },
-    { name = "tsfeatures" },
+    { name = "tsfeatures", specifier = ">=0.4.5" },
     { name = "utilsforecast", extras = ["plotting"], specifier = ">=0.2.15" },
+    { name = "wandb", specifier = "==0.22.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mktestdocs", specifier = ">=0.2.5" },
     { name = "pre-commit" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov" },
     { name = "pytest-mock", specifier = ">=3.15.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -6879,7 +6879,7 @@ docs = [
 requires-dist = [
     { name = "fire" },
     { name = "gluonts", extras = ["torch"] },
-    { name = "huggingface-hub", specifier = ">=0.36.0" },
+    { name = "huggingface-hub", specifier = ">=0.36.0,<1.0" },
     { name = "lightgbm", specifier = ">=4.6.0" },
     { name = "logfire", specifier = ">=4.7.0" },
     { name = "mlforecast", specifier = ">=1.0.2" },


### PR DESCRIPTION
Fix the standard (non-uv) pip installation speed issue by pinning sub-dependencies to versions borrowed from the `uv.lock` file.

We may want to bump the `pytest` dependency in timecopilot-toto to match the version here. 
We can't support python version 3.13+ until `timecopilot-granite-tsfm` gets a support bump to 3.13+. The upstream granite-tsfm repo has support capped at 3.13. 