### PR TITLE
fix: change Chronos default dtype from bfloat16 to float32

### DIFF
--- a/tests/models/foundation/test_chronos.py
+++ b/tests/models/foundation/test_chronos.py
@@ -37,7 +37,6 @@ def test_chronos_model_uses_configured_dtype(mocker):
 def test_chronos_forecast_uses_configured_dtype(mocker):
     """Ensure Chronos.forecast uses the configured dtype for dataset creation."""
     import pandas as pd
-
     import pytest
 
     from timecopilot.models.foundation.chronos import Chronos

--- a/tests/models/foundation/test_chronos.py
+++ b/tests/models/foundation/test_chronos.py
@@ -3,8 +3,8 @@ import torch
 from timecopilot.models.foundation.utils import TimeSeriesDataset
 
 
-def test_timeseries_dataset_default_dtype_is_float32():
-    """Ensure TimeSeriesDataset defaults to float32 for numerical precision."""
+def test_timeseries_dataset_default_dtype_is_bfloat16():
+    """Ensure TimeSeriesDataset defaults to bfloat16 for backward compatibility."""
     import pandas as pd
 
     df = pd.DataFrame(
@@ -15,7 +15,7 @@ def test_timeseries_dataset_default_dtype_is_float32():
         }
     )
     dataset = TimeSeriesDataset.from_df(df, batch_size=10)
-    assert dataset.data[0].dtype == torch.float32
+    assert dataset.data[0].dtype == torch.bfloat16
 
 
 def test_chronos_default_dtype_is_float32():

--- a/tests/models/foundation/test_chronos.py
+++ b/tests/models/foundation/test_chronos.py
@@ -1,0 +1,37 @@
+import torch
+
+from timecopilot.models.foundation.utils import TimeSeriesDataset
+
+
+def test_timeseries_dataset_default_dtype_is_float32():
+    """Ensure TimeSeriesDataset defaults to float32 for numerical precision."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "unique_id": ["A"] * 10,
+            "ds": pd.date_range("2020-01-01", periods=10),
+            "y": range(10),
+        }
+    )
+    dataset = TimeSeriesDataset.from_df(df, batch_size=10)
+    assert dataset.data[0].dtype == torch.float32
+
+
+def test_chronos_model_uses_float32(mocker):
+    """Ensure Chronos loads models with float32 dtype."""
+    mock_pipeline = mocker.patch(
+        "timecopilot.models.foundation.chronos.BaseChronosPipeline.from_pretrained"
+    )
+    mocker.patch("torch.cuda.is_available", return_value=False)
+
+    from timecopilot.models.foundation.chronos import Chronos
+
+    model = Chronos(repo_id="amazon/chronos-t5-tiny")
+
+    with model._get_model():
+        pass
+
+    mock_pipeline.assert_called_once()
+    call_kwargs = mock_pipeline.call_args[1]
+    assert call_kwargs["torch_dtype"] == torch.float32

--- a/tests/models/foundation/test_utils.py
+++ b/tests/models/foundation/test_utils.py
@@ -3,7 +3,7 @@ import torch
 from timecopilot.models.foundation.utils import TimeSeriesDataset
 
 
-def test_timeseries_dataset_default_dtype_is_bfloat16():
+def test_timeseries_dataset_class_default_dtype_is_bfloat16():
     """Ensure TimeSeriesDataset defaults to bfloat16 for backward compatibility."""
     import pandas as pd
 

--- a/tests/models/foundation/test_utils.py
+++ b/tests/models/foundation/test_utils.py
@@ -1,0 +1,33 @@
+import torch
+
+from timecopilot.models.foundation.utils import TimeSeriesDataset
+
+
+def test_timeseries_dataset_default_dtype_is_bfloat16():
+    """Ensure TimeSeriesDataset defaults to bfloat16 for backward compatibility."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "unique_id": ["A"] * 10,
+            "ds": pd.date_range("2020-01-01", periods=10),
+            "y": range(10),
+        }
+    )
+    dataset = TimeSeriesDataset.from_df(df, batch_size=10)
+    assert dataset.data[0].dtype == torch.bfloat16
+
+
+def test_timeseries_dataset_respects_custom_dtype():
+    """Ensure TimeSeriesDataset respects custom dtype parameter."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "unique_id": ["A"] * 10,
+            "ds": pd.date_range("2020-01-01", periods=10),
+            "y": range(10),
+        }
+    )
+    dataset = TimeSeriesDataset.from_df(df, batch_size=10, dtype=torch.float32)
+    assert dataset.data[0].dtype == torch.float32

--- a/timecopilot/models/foundation/chronos.py
+++ b/timecopilot/models/foundation/chronos.py
@@ -77,8 +77,8 @@ class Chronos(Forecaster):
               available, otherwise CPU).
             - For best performance with large models (e.g., "chronos-t5-large"),
               a CUDA-compatible GPU is recommended.
-            - The model weights are loaded with torch_dtype=torch.bfloat16 for
-              efficiency on supported hardware.
+            - The model weights are loaded with torch_dtype=torch.float32 for
+              numerical precision.
 
         """
         self.repo_id = repo_id
@@ -91,7 +91,7 @@ class Chronos(Forecaster):
         model = BaseChronosPipeline.from_pretrained(
             self.repo_id,
             device_map=device_map,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=torch.float32,
         )
         try:
             yield model

--- a/timecopilot/models/foundation/chronos.py
+++ b/timecopilot/models/foundation/chronos.py
@@ -224,7 +224,9 @@ class Chronos(Forecaster):
         """
         freq = self._maybe_infer_freq(df, freq)
         qc = QuantileConverter(level=level, quantiles=quantiles)
-        dataset = TimeSeriesDataset.from_df(df, batch_size=self.batch_size, dtype=self.dtype)
+        dataset = TimeSeriesDataset.from_df(
+            df, batch_size=self.batch_size, dtype=self.dtype
+        )
         fcst_df = dataset.make_future_dataframe(h=h, freq=freq)
         with self._get_model() as model:
             fcsts_mean_np, fcsts_quantiles_np = self._predict(

--- a/timecopilot/models/foundation/utils.py
+++ b/timecopilot/models/foundation/utils.py
@@ -27,7 +27,7 @@ class TimeSeriesDataset:
         cls,
         df: pd.DataFrame,
         batch_size: int,
-        dtype: torch.dtype = torch.bfloat16,
+        dtype: torch.dtype = torch.float32,
     ):
         tensors = []
         df_sorted = df.sort_values(by=["unique_id", "ds"])

--- a/timecopilot/models/foundation/utils.py
+++ b/timecopilot/models/foundation/utils.py
@@ -27,7 +27,7 @@ class TimeSeriesDataset:
         cls,
         df: pd.DataFrame,
         batch_size: int,
-        dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype = torch.bfloat16,
     ):
         tensors = []
         df_sorted = df.sort_values(by=["unique_id", "ds"])


### PR DESCRIPTION
## Summary

Changes the default `torch_dtype` for Chronos models from `bfloat16` to `float32` to improve numerical precision.

## Problem

As reported in #307 by @abdulfatir, using `bfloat16` can cause precision issues that significantly impact forecast accuracy. In [time-bench benchmarks](https://github.com/zqiao11/TIME/pull/2), switching to `float32` improved Chronos model rankings from **5th to 1st place** in terms of MASE.

## Changes

- Updated `torch_dtype` from `torch.bfloat16` to `torch.float32` in `_get_model()`
- Updated docstring to reflect the change

## Trade-offs

- **Memory**: `float32` uses 2x memory compared to `bfloat16`
- **Speed**: Slightly slower inference on hardware with native bfloat16 support
- **Accuracy**: Significantly improved forecast precision (the main benefit)

The accuracy gains outweigh the performance costs for most use cases.

Closes #307

cc @AzulGarza