### PR TITLE
fix bedrock connection error due to missing description

### DIFF
--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -937,6 +937,15 @@ class TimeCopilot:
             ctx: RunContext[ExperimentDataset],
             features: list[str],
         ) -> str:
+            """Calculate time series features to help understand the characteristics
+            of the time series data
+
+            Args:
+                features: List of feature names to calculate from available TSFEATURES
+
+            Returns:
+                Text representation of calculated features.
+            """
             callable_features = []
             for feature in features:
                 if feature not in TSFEATURES:
@@ -964,6 +973,15 @@ class TimeCopilot:
             ctx: RunContext[ExperimentDataset],
             models: list[str],
         ) -> str:
+            """Perform cross-validation to evaluate and compare multiple forecasting
+            models.
+
+            Args:
+                models: List of model names to evaluate using cross-validation.
+
+            Returns:
+                Text representation of evaluation metrics for the models.
+            """
             callable_models = []
             for str_model in models:
                 if str_model not in self.forecasters:
@@ -995,6 +1013,14 @@ class TimeCopilot:
             ctx: RunContext[ExperimentDataset],
             model: str,
         ) -> str:
+            """Generate forecast using specified forecasting model.
+
+            Args:
+                model: Name of the forecasting model to use.
+
+            Returns:
+                Text representation of the generated forecast.
+            """
             callable_model = self.forecasters[model]
             forecaster = TimeCopilotForecaster(models=[callable_model])
             fcst_df = forecaster.forecast(


### PR DESCRIPTION
Docstrings included in timecopilot/agent.py in tsfeatures_tool, cross_validation_tool and forecast_tool.
These docstrings are required by pydantic.
These changes solve the issue:
```
raise ModelHTTPError(status_code=status_code, model_name=self.model_name, body=e.response) from e
pydantic_ai.exceptions.ModelHTTPError: status_code: 400, model_name: '', body: {'Error': {'Message': 'The model returned the following errors: {"error":{"code":"validation_error","message":"ErrorEvent { error: APIError { type: \\"BadRequestError\\", code: Some(400), message: \\"1 validation error for ToolDescription\\\\ndescription\\\\n  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\\\\n    For further information visit [https://errors.pydantic.dev/2.12/v/string_type\\](https://errors.pydantic.dev/2.12/v/string_type%5C%5C)", param: None } }","param":null,"type":"invalid_request_error"}}', 'Code': 'ValidationException'}, 'ResponseMetadata': {'RequestId': '', 'HTTPStatusCode': 400, 'HTTPHeaders': {'date': 'Sat, 21 Feb 2026 15:21:32 GMT', 'content-type': 'application/json', 'content-length': '512', 'connection': 'keep-alive', 'x-amzn-requestid': '', 'x-amzn-errortype': 'ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/'}, 'RetryAttempts': 0}, 'message': 'The model returned the following errors: {"error":{"code":"validation_error","message":"ErrorEvent { error: APIError { type: \\"BadRequestError\\", code: Some(400), message: \\"1 validation error for ToolDescription\\\\ndescription\\\\n  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\\\\n    For further information visit [https://errors.pydantic.dev/2.12/v/string_type\\](https://errors.pydantic.dev/2.12/v/string_type%5C%5C)", param: None } }","param":null,"type":"invalid_request_error"}}'}
```