### PR TITLE
fix: timecopilot fork links in contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/TimeCopilot/timecopilot/actions/workflows/ci.yaml"><img src="https://github.com/TimeCopilot/timecopilot/actions/workflows/ci.yaml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://pypi.python.org/pypi/timecopilot"><img src="https://img.shields.io/pypi/v/timecopilot.svg" alt="PyPI"></a>
   <a href="https://github.com/TimeCopilot/timecopilot"><img src="https://img.shields.io/pypi/pyversions/timecopilot.svg" alt="versions"></a>
-  <a href="https://github.com/TimeCopilot/timecopilot/blob/main/LICENSE"><img src="https://img.shields.io/github/license/TimeCopilot/timecopilot.svg" alt="license"></a>
+  <a href="https://github.com/TimeCopilot/timecopilot/blob/main/LICENSE"><img src="https://img.shields.io/github/license/TimeCopilot/timecopilot" alt="license"></a>
   <a href="https://discord.gg/7GEdHR6Pfg"><img src="https://img.shields.io/discord/1387291858513821776?label=discord" alt="Join Discord" /></a>
 </div>
 

--- a/docs/changelogs/v0.0.23.md
+++ b/docs/changelogs/v0.0.23.md
@@ -1,7 +1,3 @@
-# V0.0.23 Changelog
-
-## Changes
-
 ### Features
 
 * **sktime support**: Added support for sktime models, enabling integration with the sktime forecasting ecosystem. See [#278](https://github.com/TimeCopilot/timecopilot/pull/278) and [#291](https://github.com/TimeCopilot/timecopilot/pull/291).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,28 +96,28 @@ TimeCopilot uses some forked Python packages, maintained under custom names on P
 
 - **chronos-forecasting**
     - Forked from: [amazon-science/chronos-forecasting](https://github.com/amazon-science/chronos-forecasting)
-    - TimeCopilot fork: [AzulGarza/chronos-forecasting](https://github.com/AzulGarza/chronos-forecasting/tree/feat/timecopilot-chronos-forecasting)
+    - TimeCopilot fork: [TimeCopilot/chronos-forecasting](https://github.com/TimeCopilot/chronos-forecasting/tree/feat/timecopilot-chronos-forecasting)
     - Published on PyPI as: [`timecopilot-chronos-forecasting`](https://pypi.org/project/timecopilot-chronos-forecasting/)
 
 
 - **granite-tsfm**
     - Forked from: [ibm-granite/granite-tsfm](https://github.com/ibm-granite/granite-tsfm)
-    - TimeCopilot fork: [AzulGarza/granite-tsfm](https://github.com/AzulGarza/granite-tsfm)
+    - TimeCopilot fork: [TimeCopilot/granite-tsfm](https://github.com/TimeCopilot/granite-tsfm)
     - Published on PyPI as: [`timecopilot-granite-tsfm`](https://pypi.org/project/timecopilot-granite-tsfm/)
 
 - **timesfm**
     - Forked from: [google-research/timesfm](https://github.com/google-research/timesfm)
-    - TimeCopilot fork: [AzulGarza/timesfm](https://github.com/AzulGarza/timesfm)
+    - TimeCopilot fork: [TimeCopilot/timesfm](https://github.com/TimeCopilot/timesfm)
     - Published on PyPI as: [`timecopilot-timesfm`](https://pypi.org/project/timecopilot-timesfm/)
 
 - **tirex**
     - Forked from: [NX-AI/tirex](https://github.com/NX-AI/tirex)
-    - TimeCopilot fork: [AzulGarza/tirex](https://github.com/AzulGarza/tirex)
+    - TimeCopilot fork: [TimeCopilot/tirex](https://github.com/TimeCopilot/tirex)
     - Published on PyPI as: [`timecopilot-tirex`](https://pypi.org/project/timecopilot-tirex/)
 
 - **toto**
     - Forked from: [DataDog/toto](https://github.com/DataDog/toto)
-    - TimeCopilot fork: [AzulGarza/toto](https://github.com/AzulGarza/toto)
+    - TimeCopilot fork: [TimeCopilot/toto](https://github.com/TimeCopilot/toto)
     - Published on PyPI as: [`timecopilot-toto`](https://pypi.org/project/timecopilot-toto/)
 
 - **uni2ts**:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -122,5 +122,5 @@ TimeCopilot uses some forked Python packages, maintained under custom names on P
 
 - **uni2ts**:
     - Forked from: [SalesforceAIResearch/uni2ts](https://github.com/SalesforceAIResearch/uni2ts)
-    - TimeCopilot fork: [AzulGarza/uni2ts](https://github.com/AzulGarza/uni2ts)
+    - TimeCopilot fork: [TimeCopilot/uni2ts](https://github.com/TimeCopilot/uni2ts)
     - Published on PyPI as: [`timecopilot-uni2ts`](https://pypi.org/project/timecopilot-uni2ts/)

--- a/timecopilot/models/foundation/timesfm.py
+++ b/timecopilot/models/foundation/timesfm.py
@@ -143,7 +143,7 @@ class _TimesFMV2_p5(Forecaster):
         prediction_length: int,
     ) -> TimesFM_2p5_200M_torch:
         # automatically detect the best device
-        # https://github.com/AzulGarza/timesfm/blob/b810bbdf9f8a1e66396e7bd5cdb3b005e9116d86/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py#L71
+        # https://github.com/TimeCopilot/timesfm/blob/b810bbdf9f8a1e66396e7bd5cdb3b005e9116d86/src/timesfm/timesfm_2p5/timesfm_2p5_torch.py#L71
         if os.path.exists(self.repo_id):
             path = os.path.join(self.repo_id, "model.safetensors")
             tfm = TimesFM_2p5_200M_torch().model.load_checkpoint(path)


### PR DESCRIPTION
updated timecopilot fork links to point to the new repository, and a couple of style changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/link updates plus a comment-only code change; no runtime logic or data flow is modified.
> 
> **Overview**
> Updates documentation links to reflect the move of forked dependencies from personal repos to the `TimeCopilot` organization (notably in `docs/contributing.md`), and adjusts an inline reference URL in `timesfm.py` accordingly.
> 
> Also makes small doc-only tweaks: fixes the README license badge URL and cleans up `docs/changelogs/v0.0.23.md` heading formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb7d669fe980b12920d944e114f2ec4e114b5cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->