### PR TITLE
ci: check toml in ci run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,4 +141,4 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Run pre-commit
-        run: uvx pre-commit run --all-files
+        run: uvx pre-commit run --hook-stage manual --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,20 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+        stages: [pre-commit, manual]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --check-untyped-defs]
         additional_dependencies: [types-PyYAML, types-requests]
+        stages: [pre-commit, manual]
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:
-      - id: toml-sort
+      - id: toml-sort-fix
         args: ["--all", "--trailing-comma-inline-array", "--in-place"]
+        stages: [pre-commit]
+      - id: toml-sort
+        args: ["--all", "--trailing-comma-inline-array", "--in-place", "--check"]
+        stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+        stages: [pre-commit, manual]
       - id: ruff-format
         stages: [pre-commit, manual]
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
Check toml-sort instead of sorting the file, so unsorted files are displayed in ci run.

Example output of a toml sort check failure:
```
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
toml-sort................................................................Failed
- hook id: toml-sort
- exit code: 1

1 check failure(s):
  - pyproject.toml
  ```