### PR TITLE
fix: handle stack types if h is 1

### DIFF
--- a/timecopilot/models/neural.py
+++ b/timecopilot/models/neural.py
@@ -354,6 +354,8 @@ class AutoNBEATS(Forecaster):
         if self.config is None:
             config = _AutoNBEATS.get_default_config(h=h, backend="ray")
             config["scaler_type"] = tune.choice(["robust"])
+            if h == 1:
+                config["stack_types"] = ["identity"]
         else:
             config = self.config
         if self.backend == "optuna":


### PR DESCRIPTION
this pr handles nbeats' hpo space when `h=1`.