### PR TITLE
feat: add LiteLLM support via litellm: model prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ distributed = [
   "pyspark<4.1",
   "ray==2.48",
 ]
+litellm = [
+  "litellm>=1.80.0,<1.87.0",
+]
 
 [project.scripts]
 timecopilot = "timecopilot._cli:main"

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -154,6 +154,32 @@ async def test_async_is_queryable():
 
 
 @pytest.mark.live
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+def test_litellm_forecast():
+    h = 2
+    df = generate_series(
+        n_series=1,
+        freq="D",
+        min_length=30,
+        static_as_categorical=False,
+        with_trend=True,
+    )
+    tc = TimeCopilot(
+        llm="litellm:openai/gpt-4o-mini",
+        forecasters=[
+            ZeroModel(),
+        ],
+    )
+    result = tc.forecast(
+        df=df,
+        query=f"Please forecast the series with a horizon of {h} and frequency D.",
+    )
+    assert len(result.fcst_df) == h
+    assert result.features_df is not None
+    assert result.eval_df is not None
+
+
+@pytest.mark.live
 @pytest.mark.asyncio
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 async def test_async_query_stream():

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -41,8 +41,8 @@ def _resolve_llm(llm: str | Model) -> str | Model:
     """Resolve LLM string, adding LiteLLM support for 100+ providers.
 
     If the string starts with 'litellm:', creates a pydantic-ai OpenAI model
-    pointed at a running LiteLLM proxy. Set LITELLM_BASE_URL to your proxy
-    address (default: http://localhost:4000/v1).
+    backed by litellm SDK (no proxy needed). LiteLLM reads provider API keys
+    from environment variables (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.).
 
     Examples:
         --llm litellm:anthropic/claude-sonnet-4-6
@@ -52,15 +52,17 @@ def _resolve_llm(llm: str | Model) -> str | Model:
     if not (isinstance(llm, str) and llm.startswith("litellm:")):
         return llm
 
-    import os
-
-    from openai import AsyncOpenAI
-
     model_name = llm[len("litellm:"):]
-    base_url = os.environ.get("LITELLM_BASE_URL", "http://localhost:4000/v1")
-    api_key = os.environ.get("LITELLM_API_KEY", "sk-unused")
+    try:
+        import litellm
 
-    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        litellm.drop_params = True
+        client = litellm.AsyncOpenAI()
+    except ImportError:
+        raise ImportError(
+            "litellm package required for litellm: models. "
+            "Install with: pip install 'timecopilot[litellm]'"
+        )
     return OpenAIModel(model_name, openai_client=client)
 from .models.prophet import Prophet
 from .models.stats import (

--- a/timecopilot/agent.py
+++ b/timecopilot/agent.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.models import Model
+from pydantic_ai.models.openai import OpenAIModel
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -34,6 +35,33 @@ from tsfeatures.tsfeatures import _get_feats
 
 from .forecaster import Forecaster, TimeCopilotForecaster
 from .models.adapters.sktime import SKTimeAdapter
+
+
+def _resolve_llm(llm: str | Model) -> str | Model:
+    """Resolve LLM string, adding LiteLLM support for 100+ providers.
+
+    If the string starts with 'litellm:', creates a pydantic-ai OpenAI model
+    pointed at a running LiteLLM proxy. Set LITELLM_BASE_URL to your proxy
+    address (default: http://localhost:4000/v1).
+
+    Examples:
+        --llm litellm:anthropic/claude-sonnet-4-6
+        --llm litellm:groq/llama-3.3-70b-versatile
+        --llm litellm:deepseek/deepseek-chat
+    """
+    if not (isinstance(llm, str) and llm.startswith("litellm:")):
+        return llm
+
+    import os
+
+    from openai import AsyncOpenAI
+
+    model_name = llm[len("litellm:"):]
+    base_url = os.environ.get("LITELLM_BASE_URL", "http://localhost:4000/v1")
+    api_key = os.environ.get("LITELLM_API_KEY", "sk-unused")
+
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+    return OpenAIModel(model_name, openai_client=client)
 from .models.prophet import Prophet
 from .models.stats import (
     ADIDA,
@@ -541,7 +569,7 @@ class TimeCopilot:
                 "model is not allowed to be passed as a keyword argument"
                 "use `llm` instead"
             )
-        self.llm = llm
+        self.llm = _resolve_llm(llm)
 
         self.forecasting_agent = Agent(
             deps_type=ExperimentDataset,


### PR DESCRIPTION
## Summary

Adds LiteLLM support via a `litellm:` model prefix, letting users route forecasting through 100+ LLM providers (Anthropic, Groq, Bedrock, Vertex AI, DeepSeek, etc.) using the litellm SDK directly - no proxy needed.


## Changes

- `timecopilot/agent.py` - added `_resolve_llm()` that detects `litellm:` prefix and creates a pydantic-ai model via `litellm.AsyncOpenAI()` with `drop_params=True`
- `pyproject.toml` - added `[litellm]` optional dependency (`litellm>=1.80.0,<1.87.0`)

## Example usage

```bash
pip install 'timecopilot[litellm]'

# Set your provider's API key
export ANTHROPIC_API_KEY="sk-ant-..."

# Use any litellm model string
timecopilot forecast data.csv --llm litellm:anthropic/claude-sonnet-4-6
timecopilot chat --llm litellm:groq/llama-3.3-70b-versatile
```

```python
from timecopilot import AsyncTimeCopilot

copilot = AsyncTimeCopilot(llm="litellm:anthropic/claude-sonnet-4-6")
result = await copilot.forecast(df)
```

Any [LiteLLM-supported model string](https://docs.litellm.ai/docs/providers) works: `anthropic/claude-sonnet-4-6`, `groq/llama-3.3-70b-versatile`, `bedrock/anthropic.claude-v2`, `deepseek/deepseek-chat`, etc.
